### PR TITLE
feat(permissions): self-grant READ_LOGS from root or Shizuku

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,19 +49,27 @@ expected to follow literally.
 ## 🔐 The privileged surface
 
 Loki reads **other applications'** logcat output. That needs `android.permission.READ_LOGS`, which
-is `signature|privileged` and cannot be granted to a normal app. Loki reaches it two ways:
+is `signature|privileged|development` and cannot be granted to a normal app by the user. Loki
+reaches it two ways:
 
 - **Root** — a shell via Odin, injected as `com.valhalla.superuser.ktx.ShellRepository`.
 - **Shizuku** — an ADB-privileged process via `rikka.shizuku`.
 
-So `model/PermissionManager.kt`, `model/LogcatCapture.kt` and `services/LogcatService.kt` execute
-with authority the app does not otherwise hold. When you touch any of them:
+Either channel is also used, at launch, to grant Loki the permission *itself* — see
+[Self-granting READ_LOGS](CLAUDE.md#self-granting-read_logs) for why that works, why it kills the
+process, and why the grant order is not cosmetic.
+
+So `model/PermissionManager.kt`, `model/SelfPermissionGrabber.kt`, `model/LogcatCapture.kt` and
+`services/LogcatService.kt` execute with authority the app does not otherwise hold. When you touch
+any of them:
 
 - **Never** interpolate unvalidated input into a shell string. A package name that did not come
   from `PackageManager` is a command injection into a root shell.
 - Take the `ShellRepository` **interface** from Koin; never construct a shell inline. That is what
   keeps the privileged surface swappable in a test — and countable by grep.
-- **Never** assume a privileged command succeeded. Check the exit code.
+- **Never** assume a privileged command succeeded. Check the exit code — and where the platform
+  can tell you the outcome directly, as `checkSelfPermission` does after a `pm grant`, re-read it
+  rather than inferring it from a shell's exit status.
 - Treat a captured log as sensitive data. Logcat carries tokens, URLs and third parties' PII;
   nothing in Loki may send it anywhere the user did not choose.
 - State in the PR which privilege mode(s) you actually exercised — **Root**, **Shizuku**, or

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,8 +133,11 @@ to new *runtime* behaviour and is a separate, testable change.
 ```text
 com/valhalla/loki/
   di/Modules.kt      ← the single Koin module + initKoin()
-  model/             ← PermissionManager, LogcatCapture, AppInfo, AppInfoGrabber, Packages,
-                       SavedLogs, ThemeManager, DirectoryChanges, LogLevel, Extensions
+  model/             ← PermissionManager, SelfPermissions (the pure grant rule),
+                       SelfPermissionGrabber (the launch-time sweep), SelfGrantStore (its two
+                       persisted markers), LogcatCapture, AppInfo, AppInfoGrabber, Packages,
+                       SavedLogs, Preferences (the one DataStore), ThemeManager, DirectoryChanges,
+                       LogLevel, Extensions
   services/          ← LogcatService (foreground service; the capture loop),
                        LokiDocumentsProvider (exposes logs/ to the system file picker)
   ui/
@@ -194,17 +197,129 @@ wanted. The ViewModels that need a directory are spelled out and take `get<Conte
 `.shareCacheDir`; `LogViewerViewModel` takes its file as an injected *parameter*
 (`parametersOf(file)`), one instance per file.
 
+Anything holding preferences must be a `single`, and must go through the one delegate in
+`model/Preferences.kt`. `preferencesDataStore(name = "settings")` may be instantiated **once per
+process** — a second instance over the same file throws at runtime, not at compile time — so
+`ThemeManager` and `SelfGrantStore` share `Context.settingsDataStore` and keep their own keys
+private. Do not give a new owner its own store or its own file just to avoid the import.
+
 ## The privileged surface
 
-`READ_LOGS` is `signature|privileged` and cannot be granted to a normal app. Loki reaches it through
-a root shell (**Odin**, `com.valhalla.superuser.ktx.ShellRepository`) or Shizuku (`rikka.shizuku`).
-`model/PermissionManager.kt`, `model/LogcatCapture.kt` and `services/LogcatService.kt` therefore run
-with authority the app does not hold.
+`READ_LOGS` cannot be granted to a normal app by the user. Loki reaches it through a root shell
+(**Odin**, `com.valhalla.superuser.ktx.ShellRepository`) or Shizuku (`rikka.shizuku`).
+`model/PermissionManager.kt`, `model/SelfPermissionGrabber.kt`, `model/LogcatCapture.kt` and
+`services/LogcatService.kt` therefore run with authority the app does not hold.
 
 The shell is injected as the `ShellRepository` interface, bound to `RealShellRepository` in
 `di/Modules.kt`. Take the interface, never construct a shell inline — that is what keeps the
 privileged surface swappable in a test and countable by grep. `model/SuCli.kt` is **gone**; it was
 the libsu wrapper.
+
+### Self-granting READ_LOGS
+
+The protection level is `signature|privileged|development` — note the third flag, which this file
+used to omit — with `gids=[1007, 1096]`. Device-verified on API 36 and 37. Both halves matter:
+
+- The `development` flag is the whole reason `pm grant` works at all. `PermissionManagerService`
+  accepts `isRuntimePermission || bp.isDevelopment()`, so a privileged shell can hand Loki its own
+  `READ_LOGS` without a signature match.
+- The gids are why the grant **kills the entire appId**
+  (`Killing …: permission grant or revoke changed gids`). A running process's supplementary group
+  set cannot change, so the platform restarts rather than reconciles. This is expected, not a crash.
+
+`SelfPermissionGrabber` sweeps once per launch that has a UI — `Loki.onCreate()` registers the
+Shizuku listener and starts a sweep that does nothing until `MainActivity.onCreate()` calls
+`onUiPresent()` — plus once per `recheck()`; concurrent sweeps are serialised by a mutex, not
+prevented. The rule it applies lives in `model/SelfPermissions.kt`, which has **zero `android.*`
+imports** so it can be tested on the JVM — `SelfPermissionsTest` is where the cases are written
+down. Six things about it are easy to get wrong:
+
+- **Two booleans, not Thor's one.** Thor's `planSelfGrant` gates on `isDangerous`, computed as
+  `(protectionLevel and PROTECTION_MASK_BASE) == PROTECTION_DANGEROUS`. `READ_LOGS` is
+  `2|16|32 = 50`, so that test asks `2 == 1` and structurally cannot ever grant it. Loki adds
+  `isDevelopment`, and it must be a **flag** test —
+  `(protectionFlags and PROTECTION_FLAG_DEVELOPMENT) != 0` — never a masked-base comparison.
+- **Order is load-bearing.** Survivable grants (`gids=[]`, e.g. `POST_NOTIFICATIONS`) go first and
+  fatal ones last, because the death aborts the rest of the sweep. Thor's suite actively pins the
+  opposite (`theManifestsDeclarationOrderIsPreserved`) — it never needed this, so do not copy it.
+- **The channels are asymmetric.** Root grants silently and arms a detached relaunch that survives
+  the kill; Shizuku cannot, because `newProcess` dies with its client, so a relaunch armed there
+  dies too. Shizuku therefore raises a dialog and the user reopens Loki by hand. The armed command
+  is `nohup sh -c 'sleep N; pidof <pkg> >/dev/null 2>&1 || am start …' &`, and the `pidof` half is
+  load-bearing: arming has to precede the grant, so nothing can call the command off afterwards, and
+  a grant that *failed* would otherwise be followed two seconds later by Loki hauling itself to the
+  foreground over whatever the user had moved on to. `pidof` finds our own process because the
+  command runs as root, where `/proc` is not `hidepid`-restricted, and the package name doubles as
+  the process name only because Loki declares no `android:process`.
+- **Do not trust the exit code for "the permission landed."** Each grant is confirmed by re-reading
+  `checkSelfPermission`. The plan is built from `PackageManager` alone before any privilege is
+  probed, so a launch with nothing to grant never runs `su`.
+- **The capture is claimed, not asked about.** `sweep()` still bails early on
+  `LogcatCapture.isCapturing`, but that read is stale long before the grant — the root probe alone
+  can take Odin's ten-second timeout, and on the Shizuku path a human has been reading a dialog in
+  between. `grantFatal` therefore calls `LogcatCapture.blockForPrivilegedGrant()`, which takes the
+  same monitor `start()` holds, so exactly one of the two wins and a refused claim abandons the
+  grant. Do not "simplify" that back into a second `isCapturing` read; a check-then-act cannot be
+  repaired by checking again.
+- **A headless process may not spend privilege.** `Application.onCreate` runs on *every* process
+  start, and Loki exports `LokiDocumentsProvider` with a `DOCUMENTS_PROVIDER` filter — so DocumentsUI
+  starts Loki whenever any app opens a file picker, and the sticky Shizuku callback re-enters the
+  sweep there too. `sweep()` therefore returns immediately unless `uiPresent` is set, which only
+  `MainActivity.onCreate()` does. Without it, a rooted device would get a root-manager prompt over
+  somebody else's picker, then the fatal grant, then `am start` putting Loki in the foreground on top
+  of whatever the user was doing. The `pidof` guard above cannot cover that case: the process really
+  did die, so there is nothing for `pidof` to find. That guard answers "did the grant fail?"; the
+  flag answers "was there a UI to come back to?" The gate is inside `sweep()`, not at the `start()`
+  call site, because the binder listener calls `refresh()` directly.
+
+Scope is decided by the device, not a hardcoded list: every permission Loki declares that
+`pm grant` can actually change. Adding one to the manifest needs no code edit. `POST_NOTIFICATIONS`
+consequently never shows its system prompt.
+
+**A grant is taken once, not once per launch.** `SelfGrantStore` persists the survivable permissions
+a sweep has confirmed, and `planSelfGrant` skips a `dangerous` name it finds there — so turning
+Loki's notifications off in Settings now sticks instead of lasting until the next cold start. The
+exemption is asymmetric on purpose: `development` permissions are never consulted against that set,
+because `READ_LOGS` has no switch anywhere in Settings and so its absence cannot be a user's choice.
+There is still no `pm revoke` counterpart.
+
+**The `su` probe is paid for once per install, not once per launch.** `READ_LOGS` is permanently
+ungranted on a phone with no privilege, so the plan is permanently non-empty and `resolveChannel`
+used to spawn `su` — and, on some root managers, raise a prompt — on every single cold start.
+`SelfGrantStore.rootUnavailable` remembers the answer; `SelfPermissionGrabber.recheck()`, wired to
+Settings' "Tap to re-check" row, is how someone who roots their phone later gets the probe back.
+Shizuku is still checked every sweep, because `checkSelfPermission()` costs nothing. Note this fixes
+the *sweep* only: `AppListViewModel` and `SettingsViewModel` still probe root when they need the
+answer for their own UI.
+
+`PermissionManager.isRootAvailable()` closes a cached **non-root** shell before re-probing. Odin's
+`MainShell` falls back to `exec("sh")` when `su` throws and caches that as the main shell, and
+`cached`'s getter only clears the slot when `status < 0` — a live non-root shell is `0`. Without
+the close, one failed probe pins root unavailable for the whole process and every "tap to re-check"
+is a silent no-op.
+
+### Capture precedence: root before READ_LOGS
+
+`LogcatCapture` probes root **first** and only falls back to in-process `READ_LOGS`, at the cost of
+a `su` spawn on the common path. Holding `READ_LOGS` is what subjects a client to
+`com.android.systemui/.logcat.LogAccessDialogActivity`: `logd`'s `clientIsExemptedFromUserConsent`
+exempts uid < 10000, so a `su` shell at uid 0 is never asked and an in-process reader always is.
+`LogcatManagerService` then raises the dialog only for a requester in `PROCESS_STATE_TOP` and
+silently declines anything else — and a foreground service is not `TOP`. A declined *streaming*
+reader is not killed: logd revokes the privilege and leaves it attached, so the symptom to expect is
+a capture sitting there filling nothing, not one that exits non-zero and says why.
+
+⚠️ **All of that is read from the platform's sources, not observed on a device.** Settling it needs
+root *and* `READ_LOGS` on one phone, which nobody working on this has had. The same caveat is
+written on `LogcatCapture`'s class KDoc, in more detail; keep the two in step. If the prediction is
+wrong the ordering is merely unnecessary rather than harmful, which is why it stands — but do not
+flip it to preferring `READ_LOGS` on the grounds that the app now holds it, and do not restate the
+prediction as a measurement.
+
+Root being *present but unusable* falls through to `READ_LOGS` rather than ending the capture — the
+`&&` in the mode `when`, not a nested `if`. Three ways to reach it: the `su` probe succeeded but
+`logcat` under it failed, the shell died between probe and use, or a stop arrived mid-setup. That
+hole arrived with the root-first reorder and is easy to reintroduce.
 
 Rules — the full version is in [`AGENTS.md`](AGENTS.md) and [`.github/SECURITY.md`](.github/SECURITY.md):
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,9 @@ app/src/main/java/com/valhalla/loki/
 ├── Loki.kt              ← Application class, Koin start-up
 ├── MainActivity.kt
 ├── di/Modules.kt        ← the single Koin module
-├── model/               ← AppInfo, AppInfoGrabber, SavedLogs, LogcatCapture, PermissionManager, …
+├── model/               ← AppInfo, AppInfoGrabber, SavedLogs, LogcatCapture,
+│                          PermissionManager, SelfPermissions + SelfPermissionGrabber
+│                          (the launch-time self-grant), …
 ├── services/            ← LogcatService (foreground service, dataSync), LokiDocumentsProvider
 └── ui/
     ├── navigation/      ← LokiRoute (the NavKey surface) + NavItem (bottom-bar items)
@@ -85,21 +87,28 @@ route generation — annotating a class does nothing here.
 ### The privileged surface — read this before touching it
 
 Loki reads **other applications'** logcat output. That needs `android.permission.READ_LOGS`, which
-is `signature|privileged` and therefore **not grantable to a normal app** by the user. Loki gets it
-one of two ways:
+is `signature|privileged|development` and therefore **not grantable to a normal app** by the user.
+Loki gets it one of two ways:
 
 - **Root** — a shell via Odin, injected as `com.valhalla.superuser.ktx.ShellRepository`.
 - **Shizuku** — an ADB-privileged process via `rikka.shizuku`.
 
-That makes every change in `model/PermissionManager.kt`, `model/LogcatCapture.kt` and
-`services/LogcatService.kt` security-relevant. A command assembled from a package name that came
-from anywhere but `PackageManager` is a shell-injection surface. When you change one of these:
+Either one is also what `SelfPermissionGrabber` uses at launch to grant Loki the permission itself.
+The `development` flag is why `pm grant` is allowed to; the permission's supplementary gids are why
+the grant kills the app's process. [`CLAUDE.md`](CLAUDE.md#self-granting-read_logs) writes out the
+consequences, including why the grants are issued in a specific order.
+
+That makes every change in `model/PermissionManager.kt`, `model/SelfPermissionGrabber.kt`,
+`model/LogcatCapture.kt` and `services/LogcatService.kt` security-relevant. A command assembled from
+a package name that came from anywhere but `PackageManager` is a shell-injection surface. When you
+change one of these:
 
 - Say in the PR which privilege mode(s) you tested under — **Root**, **Shizuku**, or **neither**.
 - Never interpolate unvalidated user input into a shell string.
 - Take the `ShellRepository` interface from Koin rather than constructing a shell inline, so the
   privileged surface stays swappable in a test and countable by grep.
-- Never assume a privileged command succeeded — check the exit code.
+- Never assume a privileged command succeeded — check the exit code, and prefer re-reading what
+  the platform reports (`checkSelfPermission` after a `pm grant`) over trusting that status.
 - Treat a captured log as sensitive data. Logcat carries tokens, URLs and PII; nothing in Loki may
   send it anywhere the user did not choose.
 

--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ Two things have to be true.
 
 **Root or Shizuku.** This is the part worth understanding before you install. Reading *another*
 application's logs needs `android.permission.READ_LOGS`, which Android classifies as
-`signature|privileged` — meaning **no app can ask you for it and no user can grant it**. Google
-closed that door in Android 4.1, deliberately, because a log stream is a firehose of other apps'
-secrets. So Loki borrows the privilege instead:
+`signature|privileged|development` — meaning **no app can ask you for it and no user can grant it
+from Settings**. Google closed that door in Android 4.1, deliberately, because a log stream is a
+firehose of other apps' secrets. The one door left open is a privileged shell, so that is what Loki
+borrows:
 
 | Path | What you need | Notes |
 |---|---|---|
@@ -54,8 +55,14 @@ secrets. So Loki borrows the privilege instead:
 | **Shizuku** | [Shizuku](https://shizuku.rikka.app/) running | No root needed. Pair over wireless debugging or ADB; survives until reboot. |
 | Neither | — | Loki can only read its own logs. Not useful. |
 
-Loki's onboarding walks through whichever you have. If you have neither, Shizuku is the easier one
-to get.
+Once you have one of them, Loki does the rest itself. At launch it checks whether root or Shizuku is
+available and, if so, uses that access to grant itself `READ_LOGS`. Android tears an app down the
+moment its permissions change, so **Loki closes once** when the grant lands — that is the platform
+doing its job, not a crash. With root, Loki reopens itself a couple of seconds later; with Shizuku
+it asks first and you reopen it by hand, because a Shizuku shell dies along with the app that
+started it. From then on there is nothing more to set up.
+
+If you have neither root nor Shizuku, Shizuku is the easier one to get.
 
 ## Install
 

--- a/app/src/main/java/com/valhalla/loki/Loki.kt
+++ b/app/src/main/java/com/valhalla/loki/Loki.kt
@@ -2,10 +2,31 @@ package com.valhalla.loki
 
 import android.app.Application
 import com.valhalla.loki.di.initKoin
+import com.valhalla.loki.model.SelfPermissionGrabber
+import org.koin.android.ext.android.inject
 
-class Loki: Application() {
+class Loki : Application() {
+
+    /** `by inject()` is lazy, so it resolves on first use — which is after [initKoin] below. */
+    private val selfPermissionGrabber: SelfPermissionGrabber by inject()
+
     override fun onCreate() {
         super.onCreate()
         initKoin()
+        // Here rather than in MainActivity, for two reasons. A Koin binding nobody resolves is
+        // never constructed, so a grabber that only wired itself up in its own initialiser would
+        // never run at all. And ShizukuProvider is a ContentProvider, installed *before* this
+        // method, so this is the earliest point at which the sticky binder listener can be
+        // registered without missing the delivery that has usually already happened.
+        //
+        // What this does NOT do is grant anything. onCreate runs on every process start, including
+        // the headless ones a file picker causes by reading LokiDocumentsProvider, and a fatal
+        // grant there would kill the appId and relaunch Loki over an app the user was using. The
+        // sweep therefore waits for MainActivity to call onUiPresent(); registering the listener is
+        // all that has to happen this early.
+        //
+        // start() does not block: the plan is built from binder calls on an IO thread, and root is
+        // probed only if there is actually something left to grant.
+        selfPermissionGrabber.start()
     }
 }

--- a/app/src/main/java/com/valhalla/loki/MainActivity.kt
+++ b/app/src/main/java/com/valhalla/loki/MainActivity.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.getValue
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.lifecycleScope
 import com.valhalla.asgard.components.AsgardDialogScaffold
+import com.valhalla.loki.model.LogcatCapture
 import com.valhalla.loki.model.Packages
 import com.valhalla.loki.model.PermissionManager
 import com.valhalla.loki.model.SelfGrantState
@@ -38,6 +39,14 @@ class MainActivity : ComponentActivity() {
     private val packages: Packages by inject()
     private val themeManager: ThemeManager by inject()
     private val selfPermissionGrabber: SelfPermissionGrabber by inject()
+
+    /**
+     * Only ever used to claim the capture before a grant that kills the appId.
+     *
+     * A `single`, so this is the same instance `LogcatService` runs its capture on — which is the
+     * whole point; a per-Activity copy would hand out a claim over nothing.
+     */
+    private val logcatCapture: LogcatCapture by inject()
 
     /** Null until DataStore has answered once. The splash screen stays up while it is. */
     private val themeSettings = MutableStateFlow<ThemeSettings?>(null)
@@ -217,17 +226,37 @@ class MainActivity : ComponentActivity() {
     /**
      * Arms the relaunch, then grants through the root shell.
      *
-     * Already on a coroutine and already known to have root, so this is only the ordering: arm
-     * first, grant second. The reasoning for that order — and the two device-verified failures that
-     * produced it — is on `PermissionManager.armSelfRelaunchViaRoot`.
+     * Already on a coroutine and already known to have root, so this is only the ordering: claim
+     * first, arm second, grant third. The reasoning for arming before granting — and the two
+     * device-verified failures that produced it — is on `PermissionManager.armSelfRelaunchViaRoot`.
+     *
+     * The claim is the same one `SelfPermissionGrabber.grantFatal` takes, and it is needed here for
+     * the same reason: this grant kills the whole appId, so running it under a live capture takes
+     * the foreground service and the half-written file with it, and then the armed relaunch reopens
+     * Loki over whatever the user had moved on to. Refusing costs the user nothing — the button is
+     * still there when the capture stops.
+     *
+     * Ahead of `armSelfRelaunchViaRoot`, so a refusal leaves nothing armed to fire two seconds later.
      */
     private suspend fun grantReadLogsViaRoot() {
-        permissionManager.armSelfRelaunchViaRoot()
-        val attempt = permissionManager.grantSelfViaRoot(android.Manifest.permission.READ_LOGS)
-        // Reaching this at all means we survived, which for READ_LOGS means the grant did not land.
-        if (!permissionManager.hasReadLogsPermission()) {
-            Log.w(TAG, "root could not grant READ_LOGS: ${attempt.detail}")
-            toast("Root could not grant READ_LOGS.")
+        if (!logcatCapture.blockForPrivilegedGrant()) {
+            Log.w(TAG, "root grant abandoned: a capture is running")
+            toast("A capture is running. Stop it, then grant READ_LOGS.")
+            return
+        }
+        try {
+            permissionManager.armSelfRelaunchViaRoot()
+            val attempt = permissionManager.grantSelfViaRoot(android.Manifest.permission.READ_LOGS)
+            // Reaching this at all means we survived, which for READ_LOGS means the grant did not
+            // land.
+            if (!permissionManager.hasReadLogsPermission()) {
+                Log.w(TAG, "root could not grant READ_LOGS: ${attempt.detail}")
+                toast("Root could not grant READ_LOGS.")
+            }
+        } finally {
+            // Only reached when the grant did not kill us. On the success path the claim dies with
+            // the process, which is the only cleanup it needs.
+            logcatCapture.releaseAfterPrivilegedGrant()
         }
     }
 
@@ -266,12 +295,27 @@ class MainActivity : ComponentActivity() {
      * Nothing restarts Loki on this path, and an earlier version of this comment claimed otherwise.
      * Shizuku ties its `newProcess` shell to the client, so the shell dies with us; only the root
      * path can arm a relaunch, which is what `grantReadLogsViaRoot` does.
+     *
+     * Claimed like the root path, and for the same reason: the kill is the channel-independent half.
+     * The claim is taken here rather than in [requestPrivilegeGrant] on purpose — this path can sit
+     * inside Shizuku's own permission dialog for as long as the user takes to read it, and a claim
+     * held across that would block captures the user is entitled to start, on an abort path that may
+     * never come back.
      */
     private fun grantReadLogs() {
         shizukuGrantPending = false
         lifecycleScope.launch {
-            if (!permissionManager.grantReadLogsViaShizuku()) {
-                toast("Shizuku could not grant READ_LOGS.")
+            if (!logcatCapture.blockForPrivilegedGrant()) {
+                Log.w(TAG, "Shizuku grant abandoned: a capture is running")
+                toast("A capture is running. Stop it, then grant READ_LOGS.")
+                return@launch
+            }
+            try {
+                if (!permissionManager.grantReadLogsViaShizuku()) {
+                    toast("Shizuku could not grant READ_LOGS.")
+                }
+            } finally {
+                logcatCapture.releaseAfterPrivilegedGrant()
             }
         }
     }

--- a/app/src/main/java/com/valhalla/loki/MainActivity.kt
+++ b/app/src/main/java/com/valhalla/loki/MainActivity.kt
@@ -8,12 +8,18 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Key
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.lifecycleScope
+import com.valhalla.asgard.components.AsgardDialogScaffold
 import com.valhalla.loki.model.Packages
 import com.valhalla.loki.model.PermissionManager
+import com.valhalla.loki.model.SelfGrantState
+import com.valhalla.loki.model.SelfPermissionGrabber
 import com.valhalla.loki.model.ThemeManager
 import com.valhalla.loki.model.ThemeMode
 import com.valhalla.loki.model.ThemeSettings
@@ -31,6 +37,7 @@ class MainActivity : ComponentActivity() {
     private val permissionManager: PermissionManager by inject()
     private val packages: Packages by inject()
     private val themeManager: ThemeManager by inject()
+    private val selfPermissionGrabber: SelfPermissionGrabber by inject()
 
     /** Null until DataStore has answered once. The splash screen stays up while it is. */
     private val themeSettings = MutableStateFlow<ThemeSettings?>(null)
@@ -54,6 +61,14 @@ class MainActivity : ComponentActivity() {
         Shizuku.addBinderDeadListener(shizukuBinderDeadListener)
         Shizuku.addRequestPermissionResultListener(shizukuPermissionListener)
 
+        // The sweep Loki.onCreate() kicked off deliberately did nothing. Application.onCreate runs
+        // for headless process starts too — any app opening a file picker makes DocumentsUI read
+        // LokiDocumentsProvider, which starts this process — and a privileged grant there kills the
+        // appId and lets the armed relaunch put Loki over whatever the user was doing. This is the
+        // first point at which a UI provably exists, so it is where the sweep is allowed to spend
+        // privilege. Idempotent: a rotation re-enters here and returns.
+        selfPermissionGrabber.onUiPresent()
+
         // DataStore answers asynchronously, so the first composition would otherwise paint the
         // DEFAULT theme and flip to the stored one a frame or two later — a visible flash on every
         // cold start for anyone who is not on the defaults. Holding the splash costs nothing (it is
@@ -66,6 +81,9 @@ class MainActivity : ComponentActivity() {
 
         setContent {
             val settings by themeSettings.collectAsState()
+            // collectAsState, not collectAsStateWithLifecycle: lifecycle-runtime-compose is not a
+            // dependency, so the lifecycle-aware variant does not exist here.
+            val grantState by selfPermissionGrabber.state.collectAsState()
             // Nothing to draw until the stored theme arrives; the splash screen covers this.
             settings?.let { theme ->
                 LokiTheme(
@@ -91,8 +109,36 @@ class MainActivity : ComponentActivity() {
                     //if (canGoForward) {
                     HomeScreen(
                         onExitConfirmed = { finish() },
-                        onRequestShizuku = { requestShizuku() },
+                        onRequestPrivilege = { requestPrivilegeGrant() },
                     )
+
+                    // Only the Shizuku path ever reaches this. Root grants silently and puts Loki
+                    // back on its own, which is the difference the user chose; Shizuku cannot,
+                    // because the shell running the grant is torn down with us — so it asks.
+                    (grantState as? SelfGrantState.Offered)?.let { offer ->
+                        // Keyed on the offer, so it logs once per offer rather than once per
+                        // recomposition — a bare Log.d in a composable body is a log per frame.
+                        LaunchedEffect(offer) {
+                            Log.d(TAG, "offering ${offer.permissions.joinToString()} via ${offer.channel}")
+                        }
+                        AsgardDialogScaffold(
+                            onDismissRequest = { selfPermissionGrabber.dismissOffered() },
+                            title = "Grant READ_LOGS and close Loki?",
+                            // Deliberately does not promise prompt-free capture: holding
+                            // READ_LOGS is what subjects Loki to logd's per-request consent
+                            // dialog. What the grant actually buys is persistence — it survives a
+                            // reboot, and the user can stop using Shizuku entirely.
+                            text = "Loki can take this permission for itself using the access " +
+                                "you have already granted it. Android closes an app when its " +
+                                "permissions change, so Loki will shut down as soon as the grant " +
+                                "lands — that is expected, not a crash. Reopen it afterwards and " +
+                                "it can read other apps' logs without any further setup.",
+                            icon = Icons.Filled.Key,
+                            confirmText = "Grant and close",
+                            dismissText = "Not now",
+                            onConfirm = { selfPermissionGrabber.confirmOffered() },
+                        )
+                    }
                     /*} else {
                         OnboardingScreen(
                             onShizukuRequested = {
@@ -126,12 +172,23 @@ class MainActivity : ComponentActivity() {
      */
     private var shizukuGrantPending = false
 
-    private fun requestShizuku() {
+    /**
+     * The user asked for `READ_LOGS`. Routes to whichever privilege can actually deliver it.
+     *
+     * Root first, and that arm used to be a dead end: this method logged "root available; no
+     * Shizuku grant needed" and returned, so a rooted user confirmed a dialog promising "Grant and
+     * close" and nothing happened, with no message. Root can grant — it just could not before,
+     * because there was no root grant path to route to.
+     */
+    private fun requestPrivilegeGrant() {
         // isRootAvailable() suspends — a root probe must not run on the main thread.
         lifecycleScope.launch {
             try {
                 if (permissionManager.isRootAvailable()) {
-                    Log.d(TAG, "root available; no Shizuku grant needed")
+                    // No confirmation and no toast on success, because there is nobody left to
+                    // show one to: the grant kills this process, and the armed relaunch inside
+                    // grantViaRoot is what brings Loki back.
+                    grantReadLogsViaRoot()
                     return@launch
                 }
 
@@ -158,7 +215,24 @@ class MainActivity : ComponentActivity() {
     }
 
     /**
-     * Second half of [requestShizuku] — reached directly when Shizuku is already up, or from
+     * Arms the relaunch, then grants through the root shell.
+     *
+     * Already on a coroutine and already known to have root, so this is only the ordering: arm
+     * first, grant second. The reasoning for that order — and the two device-verified failures that
+     * produced it — is on `PermissionManager.armSelfRelaunchViaRoot`.
+     */
+    private suspend fun grantReadLogsViaRoot() {
+        permissionManager.armSelfRelaunchViaRoot()
+        val attempt = permissionManager.grantSelfViaRoot(android.Manifest.permission.READ_LOGS)
+        // Reaching this at all means we survived, which for READ_LOGS means the grant did not land.
+        if (!permissionManager.hasReadLogsPermission()) {
+            Log.w(TAG, "root could not grant READ_LOGS: ${attempt.detail}")
+            toast("Root could not grant READ_LOGS.")
+        }
+    }
+
+    /**
+     * Second half of [requestPrivilegeGrant] — reached directly when Shizuku is already up, or from
      * [shizukuBinderReceivedListener] once it arrives.
      */
     private fun continueShizukuGrant() {
@@ -186,9 +260,12 @@ class MainActivity : ComponentActivity() {
      * Runs the actual `pm grant`.
      *
      * There is no success toast, because there is nobody left to show one to: granting
-     * `READ_LOGS` kills this process (see `PermissionManager.grantReadLogsViaShizuku`), which
-     * then restarts itself from the Shizuku shell. Reaching the toast below at all means the
-     * grant failed and we survived to say so.
+     * `READ_LOGS` kills this process (see `PermissionManager.grantReadLogsViaShizuku`). Reaching
+     * the toast below at all means the grant failed and we survived to say so.
+     *
+     * Nothing restarts Loki on this path, and an earlier version of this comment claimed otherwise.
+     * Shizuku ties its `newProcess` shell to the client, so the shell dies with us; only the root
+     * path can arm a relaunch, which is what `grantReadLogsViaRoot` does.
      */
     private fun grantReadLogs() {
         shizukuGrantPending = false

--- a/app/src/main/java/com/valhalla/loki/di/Modules.kt
+++ b/app/src/main/java/com/valhalla/loki/di/Modules.kt
@@ -6,6 +6,8 @@ import com.valhalla.loki.model.AppInfoGrabber
 import com.valhalla.loki.model.LogcatCapture
 import com.valhalla.loki.model.Packages
 import com.valhalla.loki.model.PermissionManager
+import com.valhalla.loki.model.SelfGrantStore
+import com.valhalla.loki.model.SelfPermissionGrabber
 import com.valhalla.loki.model.ThemeManager
 import com.valhalla.loki.model.logsDir
 import com.valhalla.loki.model.shareCacheDir
@@ -37,7 +39,24 @@ var appModules = module {
     // Single, because a second instance would be a second DataStore over the same file, which
     // throws. Resolves `Context` from androidContext(), like Packages does.
     singleOf(::ThemeManager)
+    // Shares that one DataStore rather than opening its own — see model/Preferences.kt.
+    singleOf(::SelfGrantStore)
     singleOf(::LogcatCapture)
+    // Spelled out rather than singleOf(::X): the constructor takes a String and a PackageManager,
+    // and an unqualified `String` binding would be the same mistake the removed
+    // `single<File> { filesDir }` was — every future String dependency silently resolving to the
+    // package name. There is no component scan here, so this line *is* the binding; annotating the
+    // class does nothing. Nothing resolves it lazily either, which is why `Loki.onCreate` asks for
+    // it by hand.
+    single {
+        SelfPermissionGrabber(
+            packageName = androidContext().packageName,
+            packageManager = androidContext().packageManager,
+            permissionManager = get(),
+            logcatCapture = get(),
+            store = get(),
+        )
+    }
     viewModelOf(::AppListViewModel)
     viewModelOf(::HomeViewModel)
     viewModelOf(::OnboardingViewModel)
@@ -71,6 +90,7 @@ var appModules = module {
             permissionManager = get(),
             logcatCapture = get(),
             themeManager = get(),
+            selfPermissionGrabber = get(),
             logsDir = get<Context>().logsDir,
         )
     }

--- a/app/src/main/java/com/valhalla/loki/model/LogcatCapture.kt
+++ b/app/src/main/java/com/valhalla/loki/model/LogcatCapture.kt
@@ -24,8 +24,24 @@ enum class CaptureMode { NONE, READ_LOGS, ROOT }
  * Streams one app's logcat output into a file.
  *
  * Two privilege paths, in preference order:
- *  - **READ_LOGS** granted directly (Shizuku or ADB) — a plain [ProcessBuilder], no shell at all.
  *  - **Root** — a *dedicated* Odin shell, not the process-wide main shell.
+ *  - **READ_LOGS** granted directly (Shizuku or ADB) — a plain [ProcessBuilder], no shell at all.
+ *
+ * Root first, which is not the obvious order and was not the original one. Holding `READ_LOGS` is
+ * exactly what subjects a caller to logd's per-request consent gate
+ * (`com.android.systemui/.logcat.LogAccessDialogActivity`), and a `su` logcat sidesteps it entirely.
+ *
+ * ⚠️ **That reasoning is read from the platform's sources, not observed here.** Settling it on
+ * hardware needs root *and* `READ_LOGS` on one device, which nobody working on this has had, so what
+ * follows is a prediction and is labelled as one. `logd`'s `clientIsExemptedFromUserConsent` exempts
+ * clients below uid 10000, which covers a root shell at uid 0 and never covers an app; and
+ * `LogcatManagerService` raises the dialog only for a requester in `PROCESS_STATE_TOP`, declining
+ * anything else with no prompt and no diagnostic. A capture runs under a foreground service, which
+ * is not TOP. A declined *streaming* reader is not killed either — logd revokes its privilege and
+ * leaves it attached — so the symptom to expect is a capture that sits there filling nothing, rather
+ * than one that exits non-zero and says why. Self-granting `READ_LOGS` would have *demoted* every
+ * rooted user's capture into that path, which is the reason this order changed; if the prediction
+ * turns out wrong, the order is merely unnecessary rather than harmful.
  *
  * The dedicated shell is not a stylistic choice. `logcat` without `-d` never exits, Odin cannot
  * interrupt an in-flight command, and cancelling an `asFlow()` collector only stops emission while
@@ -62,6 +78,15 @@ class LogcatCapture(
     @Volatile
     private var stopping = false
 
+    /**
+     * Set while a self-grant is about to issue a command that kills Loki's whole appId.
+     *
+     * See [blockForPrivilegedGrant] for why this exists rather than the grabber reading
+     * [isCapturing] a second time.
+     */
+    @Volatile
+    private var blockedForGrant = false
+
     /** The shell owning the streaming `logcat`. Closing it is how the capture stops. */
     private var captureShell: Shell? = null
 
@@ -70,6 +95,39 @@ class LogcatCapture(
 
     val isCapturing: Boolean
         get() = job?.isActive == true
+
+    /**
+     * Reserves this instance for a grant that will kill the whole appId, or refuses because a
+     * capture is already running.
+     *
+     * **This is a claim, not a question, and that is the point.** `SelfPermissionGrabber` used to
+     * read [isCapturing] once at the top of its sweep and then go on to probe root — up to Odin's
+     * ten-second timeout — before granting. A capture started anywhere in that window was killed by
+     * the grant, taking its foreground service and its half-written file with it, and no amount of
+     * re-reading a flag fixes a check-then-act. Taking the same monitor [start] holds does: exactly
+     * one of the two wins, and whichever loses does nothing.
+     *
+     * Returns `false` when a capture is running, in which case the caller must abandon the grant and
+     * leave its retry open — the capture is the user's work, the grant is housekeeping.
+     */
+    @Synchronized
+    fun blockForPrivilegedGrant(): Boolean {
+        if (isCapturing) return false
+        blockedForGrant = true
+        return true
+    }
+
+    /**
+     * Releases a claim taken by [blockForPrivilegedGrant].
+     *
+     * Only ever reached when the grant did *not* kill us, which — for a permission carrying
+     * supplementary gids — means it did not land. On the success path the flag dies with the process,
+     * which is the only cleanup it needs.
+     */
+    @Synchronized
+    fun releaseAfterPrivilegedGrant() {
+        blockedForGrant = false
+    }
 
     /**
      * Begins capturing [appInfo]'s logs into [outputFile].
@@ -100,21 +158,40 @@ class LogcatCapture(
             var mode = CaptureMode.NONE
             try {
                 mode = when {
+                    // Checked here rather than as an early return from start(), so a refusal still
+                    // funnels through the `finally` below. `onExit` is how LogcatService tears down
+                    // the foreground service it has already started; returning early would leave it
+                    // running with no capture behind it.
+                    blockedForGrant -> {
+                        Log.w(TAG, "a privileged self-grant is in flight; not starting a capture")
+                        CaptureMode.NONE
+                    }
+
                     uid == null -> {
                         Log.e(TAG, "no uid for ${appInfo.packageName}; not installed for this user")
                         CaptureMode.NONE
                     }
 
-                    permissionManager.hasReadLogsPermission() -> {
-                        captureWithReadLogs(uid, outputFile)
-                        CaptureMode.READ_LOGS
-                    }
+                    // Root is probed first, and the cost of that is real: it spawns or reuses `su`.
+                    // It is still the right order — see the class KDoc for what preferring
+                    // READ_LOGS costs a rooted user — and the probe is bounded by Odin's timeout.
+                    //
+                    // `&&` rather than a nested `if`, so that root being present but unusable falls
+                    // through to READ_LOGS instead of ending the capture. Three ways to get there:
+                    // the root manager withdraws between the probe and the shell, the shell comes
+                    // back unprivileged, or `logcat` rejects the uid filter under root. This hole
+                    // arrived with the reorder — before it, a rooted user holding READ_LOGS took the
+                    // READ_LOGS arm anyway and never noticed.
+                    permissionManager.isRootAvailable() && captureWithRoot(uid, outputFile) ->
+                        CaptureMode.ROOT
 
-                    permissionManager.isRootAvailable() ->
-                        if (captureWithRoot(uid, outputFile)) CaptureMode.ROOT else CaptureMode.NONE
+                    permissionManager.hasReadLogsPermission() &&
+                        captureWithReadLogs(uid, outputFile) -> CaptureMode.READ_LOGS
 
+                    // Reached both when there is no privilege at all and when every privilege
+                    // there is refused the command, which is why it no longer claims the former.
                     else -> {
-                        Log.w(TAG, "no privilege available; nothing to capture")
+                        Log.w(TAG, "no privilege produced a capture; nothing to record")
                         CaptureMode.NONE
                     }
                 }
@@ -224,10 +301,15 @@ class LogcatCapture(
      * stderr is deliberately *not* folded into the capture. A user's log file should contain log
      * lines; a diagnostic from our own tooling in the middle of it is corruption, and it is also
      * how a permission failure would come to look like ordinary content.
+     *
+     * Returns whether a capture ran, for the same reason [captureWithRoot] does: `false` means the
+     * handle was refused because [stop] had already been asked for, and recording
+     * [CaptureMode.READ_LOGS] for a `logcat` nobody ever read from points the next reader of a bug
+     * report at the wrong privilege.
      */
-    private fun captureWithReadLogs(uid: Int, outputFile: File) {
+    private fun captureWithReadLogs(uid: Int, outputFile: File): Boolean {
         val process = ProcessBuilder("logcat", "-T", "1", "--uid=$uid").start()
-        if (!adopt(process = process)) return
+        if (!adopt(process = process)) return false
         try {
             drainUntilClosed {
                 outputFile.bufferedWriter().use { writer ->
@@ -239,6 +321,7 @@ class LogcatCapture(
         } finally {
             process.destroy()
         }
+        return true
     }
 
     /**
@@ -298,6 +381,10 @@ class LogcatCapture(
         if (!probe.isSuccess) {
             val why = probe.stderr.joinToString(" ").trim()
             Log.e(TAG, "root logcat probe exited ${probe.code}" + if (why.isEmpty()) "" else ": $why")
+            // The shell was adopted a few lines up and is still open. The caller now falls through
+            // to the READ_LOGS arm, which would leave a root shell alive for the whole of that
+            // capture — held by a branch that gave up — until the `finally` in start() got to it.
+            release()
             return false
         }
 

--- a/app/src/main/java/com/valhalla/loki/model/PermissionManager.kt
+++ b/app/src/main/java/com/valhalla/loki/model/PermissionManager.kt
@@ -5,7 +5,9 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.util.Log
 import androidx.core.content.ContextCompat
+import com.valhalla.superuser.Shell
 import com.valhalla.superuser.ktx.ShellRepository
+import com.valhalla.superuser.ktx.ShellResult
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import moe.shizuku.server.IShizukuService
@@ -16,6 +18,22 @@ enum class PermissionMethod {
     ADB, // Indicates permission was granted via ADB/Shizuku
     ROOT   // Indicates we are using a root shell
 }
+
+/** Which privilege gateway a grant went through. */
+enum class GrantChannel { NONE, ROOT, SHIZUKU }
+
+/**
+ * What a privilege channel *reported* about one grant.
+ *
+ * Never the answer to "is it granted now" — [PermissionManager.isHeld] is. `pm grant` exits 0 on
+ * some ROMs while the permission stays ungranted, and a channel can report failure for a grant that
+ * landed, so the two questions are kept apart on purpose.
+ */
+data class GrantAttempt(
+    val channel: GrantChannel,
+    val reportedSuccess: Boolean,
+    val detail: String = "",
+)
 
 /**
  * The single place that answers "what privilege does Loki actually have right now?".
@@ -36,22 +54,39 @@ class PermissionManager(
 ) {
 
     /**
+     * Whether Loki itself holds [permission] right now.
+     *
+     * The authority every verification asks, and the reason a grant is never trusted on the
+     * strength of an exit code.
+     */
+    fun isHeld(permission: String): Boolean =
+        ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+
+    /**
      * Checks if the app has been granted the READ_LOGS permission directly.
      */
-    fun hasReadLogsPermission(): Boolean {
-        return ContextCompat.checkSelfPermission(
-            context,
-            Manifest.permission.READ_LOGS
-        ) == PackageManager.PERMISSION_GRANTED
-    }
+    fun hasReadLogsPermission(): Boolean = isHeld(Manifest.permission.READ_LOGS)
 
     /**
      * Checks if a root shell is available.
      *
      * Backed by Odin's bounded probe: it never throws and cannot hang forever — a shell that
      * fails to initialise inside Odin's timeout reports `false` rather than blocking.
+     *
+     * **The close is not defensive tidying, it is the whole reason re-checking works.** Odin caches
+     * one main shell process-wide, and `BuilderImpl.start()` falls back to `exec("sh")` when `su` is
+     * refused — then caches *that* as the main shell. `MainShell.cached` only drops a shell whose
+     * `status < 0`, and a live non-root shell has `NON_ROOT_SHELL == 0`, so without this every
+     * later probe answers the *first* probe's question forever. A user who grants root in their root
+     * manager while Loki is open could never be seen to have done so, which silently falsified
+     * every "tap to re-check" in the app. `Shell.close()` sets `status = UNKNOWN`, which is what
+     * lets the next `get()` rebuild through `su`.
      */
-    suspend fun isRootAvailable(): Boolean = shell.isRootGranted()
+    suspend fun isRootAvailable(): Boolean {
+        runCatching { Shell.cachedShell?.takeIf { !it.isRoot }?.close() }
+            .onFailure { Log.d(TAG, "could not invalidate the cached non-root shell", it) }
+        return shell.isRootGranted()
+    }
 
     /**
      * Checks if Shizuku is installed, running, and if LOKI has been granted permission.
@@ -62,6 +97,103 @@ class PermissionManager(
             Shizuku.checkSelfPermission() == PackageManager.PERMISSION_GRANTED
         } catch (_: Exception) {
             false
+        }
+    }
+
+    /**
+     * Grants one of **Loki's own** permissions through the root shell.
+     *
+     * Goes through the injected [ShellRepository] rather than `Shell.Builder`, per AGENTS.md: the
+     * privileged surface stays swappable in a test and countable by grep. Odin's `exec` never
+     * throws for a command failure — `code == ShellResult.JOB_NOT_EXECUTED` is a dead shell rather
+     * than a rejected command — so branching on the code is how rule 3 is satisfied here.
+     *
+     * One caveat that inverts the usual reading of a return value: for a `development` permission
+     * the platform kills us *during* this call, so getting a value back at all usually means the
+     * grant did **not** land. Verification belongs to the next process, which is what
+     * [isHeld] answers on its first cheap read at startup.
+     */
+    suspend fun grantSelfViaRoot(permission: String): GrantAttempt {
+        val command = selfGrantCommand(context.packageName, permission)
+            ?: return GrantAttempt(GrantChannel.ROOT, false, "refused an unsafe argument")
+        val result = shell.exec(command)
+        val detail = result.stderr.joinToString(" ").trim()
+        if (!result.isSuccess) {
+            val why = if (result.code == ShellResult.JOB_NOT_EXECUTED) "no shell" else "exit ${result.code}"
+            Log.w(TAG, "root pm grant of $permission failed ($why): $detail")
+        }
+        return GrantAttempt(GrantChannel.ROOT, result.isSuccess, detail)
+    }
+
+    /**
+     * Arms a detached root command that reopens Loki after the platform kills it for a grant.
+     *
+     * **Call this before the fatal grant, never after.** The two dead ends recorded on
+     * [grantReadLogsViaShizuku] are both about ordering: a chained `am start` was delivered to the
+     * already-dying Activity, and a version that forced the death first never reached its second
+     * command. Arming first, with a sleep long enough for the kill to complete, is what is left.
+     *
+     * Root-only, and that is not a policy choice. Shizuku ties a `newProcess` shell to the client
+     * that asked for it, so nothing started from one can outlive us; a Magisk root shell is forked
+     * from `magiskd` and carries no death signal, so a fully detached grandchild should survive.
+     * *Should* — this is the one claim here that no emulator can settle, and the PR says so.
+     *
+     * Returns whether the shell accepted the arming command, which is not the same as "Loki will
+     * come back". The command cannot be called off once armed, so it calls *itself* off: it starts
+     * the Activity only if our process has actually gone, which is what stops a failed grant from
+     * being followed two seconds later by an app that launches itself over whatever the user is
+     * doing. [selfRelaunchCommand] has the rest of that reasoning.
+     */
+    suspend fun armSelfRelaunchViaRoot(): Boolean {
+        val component = context.packageManager
+            .getLaunchIntentForPackage(context.packageName)
+            ?.component
+        if (component == null) {
+            Log.w(TAG, "no launcher component; cannot arm a relaunch")
+            return false
+        }
+        val command = selfRelaunchCommand(
+            packageName = component.packageName,
+            activityClassName = component.className,
+            delaySeconds = RELAUNCH_DELAY_SECONDS,
+        )
+        if (command == null) {
+            Log.w(TAG, "refused to arm a relaunch for ${component.flattenToShortString()}")
+            return false
+        }
+        val result = shell.exec(command)
+        if (!result.isSuccess) {
+            Log.w(TAG, "could not arm the relaunch (exit ${result.code})")
+        }
+        return result.isSuccess
+    }
+
+    /**
+     * Grants one of **Loki's own** permissions through Shizuku.
+     *
+     * The command stays an argv list rather than a `sh -c` string, so nothing here is a shell
+     * string at all — see [grantReadLogsViaShizuku] for the rest of the reasoning, and for why a
+     * `true` from this is a value almost nobody lives to read.
+     */
+    suspend fun grantSelfViaShizuku(permission: String): GrantAttempt = withContext(Dispatchers.IO) {
+        if (!isShizukuAvailable()) {
+            return@withContext GrantAttempt(GrantChannel.SHIZUKU, false, "Shizuku is not available")
+        }
+        return@withContext try {
+            val service = IShizukuService.Stub.asInterface(Shizuku.getBinder())
+            val process = service.newProcess(
+                arrayOf("pm", "grant", context.packageName, permission),
+                null,
+                null,
+            )
+            val code = process.waitFor()
+            if (code != 0) Log.w(TAG, "Shizuku pm grant of $permission exited $code")
+            GrantAttempt(GrantChannel.SHIZUKU, code == 0, if (code == 0) "" else "exit $code")
+        } catch (e: Exception) {
+            // Log.w, not printStackTrace(): the latter lands under the `System.err` tag, which is
+            // exactly why this failing silently cost a device session to find.
+            Log.w(TAG, "Shizuku could not grant $permission", e)
+            GrantAttempt(GrantChannel.SHIZUKU, false, e.message.orEmpty())
         }
     }
 
@@ -88,31 +220,26 @@ class PermissionManager(
      *
      * Surviving that would need a Shizuku *user service* (`addUserService`), which is a real
      * feature, not a detail of this method. Until then the UI warns before calling this and the
-     * user reopens Loki — see the confirmation in `SettingsScreen`.
+     * user reopens Loki — see the confirmation in `SettingsScreen`. **Root is different**, and
+     * [armSelfRelaunchViaRoot] is where that difference is spent.
      *
      * The command stays an argv list rather than a `sh -c` string. Nothing here needs a shell any
      * more, and the package name is ours, so there is nothing an attacker controls — but keeping
      * the argv form is what makes that still true if the argument ever stops being ours.
      */
-    suspend fun grantReadLogsViaShizuku(): Boolean = withContext(Dispatchers.IO) {
-        if (!isShizukuAvailable()) return@withContext false
-        return@withContext try {
-            val service = IShizukuService.Stub.asInterface(Shizuku.getBinder())
-            val process = service.newProcess(
-                arrayOf("pm", "grant", context.packageName, Manifest.permission.READ_LOGS),
-                null,
-                null,
-            )
-            process.waitFor() == 0
-        } catch (e: Exception) {
-            // Log.w, not printStackTrace(): the latter lands under the `System.err` tag, which is
-            // exactly why this failing silently cost a device session to find.
-            Log.w(TAG, "Shizuku could not grant READ_LOGS", e)
-            false
-        }
-    }
+    suspend fun grantReadLogsViaShizuku(): Boolean =
+        grantSelfViaShizuku(Manifest.permission.READ_LOGS).reportedSuccess
 
     private companion object {
         private const val TAG = "PermissionManager"
+
+        /**
+         * How long the armed relaunch waits before calling `am start`.
+         *
+         * Long enough for the platform's kill to finish — an `am start` that races it is delivered
+         * to the dying Activity and thrown away with it, which is the first of the two dead ends
+         * above. Short enough that the app appears to restart rather than to have crashed.
+         */
+        private const val RELAUNCH_DELAY_SECONDS = 2
     }
 }

--- a/app/src/main/java/com/valhalla/loki/model/Preferences.kt
+++ b/app/src/main/java/com/valhalla/loki/model/Preferences.kt
@@ -1,0 +1,19 @@
+package com.valhalla.loki.model
+
+import android.content.Context
+import androidx.datastore.preferences.preferencesDataStore
+
+/**
+ * The one preferences DataStore in the process.
+ *
+ * `preferencesDataStore` hands out a single instance per delegate, and building a *second* one over
+ * the same file throws at runtime — so this is shared rather than duplicated. It used to be
+ * `private` inside `ThemeManager.kt`, whose comment already said that anything else wanting a
+ * preference had to add a key there or go through `ThemeManager`. [SelfGrantStore] is the second
+ * thing that wanted one, and it is not a theme setting, so the delegate moved out here instead of
+ * its keys moving in.
+ *
+ * `internal`, so the file cannot be opened from outside `:app`, and each owner keeps its own keys
+ * private to itself.
+ */
+internal val Context.settingsDataStore by preferencesDataStore(name = "settings")

--- a/app/src/main/java/com/valhalla/loki/model/SelfGrantStore.kt
+++ b/app/src/main/java/com/valhalla/loki/model/SelfGrantStore.kt
@@ -1,0 +1,93 @@
+package com.valhalla.loki.model
+
+import android.content.Context
+import android.util.Log
+import androidx.datastore.preferences.core.MutablePreferences
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.first
+import java.io.IOException
+
+/**
+ * The two things a self-grant sweep has to remember across process death.
+ *
+ * A process-memory latch was the original design and the class KDoc on [SelfPermissionGrabber] used
+ * to argue that it was enough, because the re-read that matters happens at the top of the next
+ * launch. That argument holds for *success* and fails for the two cases where the right answer is
+ * "do nothing again":
+ *
+ *  - **A grant the user later undid.** [grantedOnce] is what separates "never asked" from "denied on
+ *    purpose", which [planSelfGrant] cannot tell from a `PackageManager` read alone. Without it,
+ *    turning Loki's notifications off in Settings lasted exactly until the next cold start.
+ *  - **A gateway that is not there.** [rootUnavailable] keeps the sweep from spending a `su` spawn —
+ *    and, on a device whose root manager asks, a prompt — on every launch of an app that has no root
+ *    and never will. A user who grants root later gets it back with one tap; see
+ *    [SelfPermissionGrabber.recheck].
+ *
+ * Both are markers rather than a mirror of the permission state. The authority on "is it granted
+ * now" is still [PermissionManager.isHeld] — nothing here is ever consulted for that.
+ */
+class SelfGrantStore(private val context: Context) {
+
+    /**
+     * The survivable permissions a sweep has taken at least once.
+     *
+     * Only ever grows. A name in here that Loki does *not* currently hold was revoked after we
+     * granted it, and the only actor who can revoke a `dangerous` permission through the UI is the
+     * user — so the sweep leaves it alone from then on.
+     */
+    suspend fun grantedOnce(): Set<String> = preferences()[KEY_GRANTED_ONCE].orEmpty()
+
+    /** Adds [permissions] to [grantedOnce]. A no-op for an empty collection, including no write. */
+    suspend fun recordGranted(permissions: Collection<String>) {
+        if (permissions.isEmpty()) return
+        edit { prefs ->
+            prefs[KEY_GRANTED_ONCE] = prefs[KEY_GRANTED_ONCE].orEmpty() + permissions
+        }
+    }
+
+    /** Whether the last root probe found no root. Absent — a fresh install — reads as `false`. */
+    suspend fun rootUnavailable(): Boolean = preferences()[KEY_ROOT_UNAVAILABLE] == true
+
+    /**
+     * Records what a root probe found.
+     *
+     * Guarded by a read, so the overwhelmingly common call — "still no root, same as last time" —
+     * costs no disk write at all.
+     */
+    suspend fun setRootUnavailable(unavailable: Boolean) {
+        if (rootUnavailable() == unavailable) return
+        edit { it[KEY_ROOT_UNAVAILABLE] = unavailable }
+    }
+
+    /**
+     * One snapshot of the store, degrading to defaults on [IOException].
+     *
+     * The same treatment [ThemeManager] gives its read path, and for a sharper reason here: this is
+     * consulted on the path that decides whether to issue a privileged command, so an unreadable
+     * preferences file must fall back to "nothing remembered" rather than throw into the sweep.
+     */
+    private suspend fun preferences(): Preferences = context.settingsDataStore.data
+        .catch { cause -> if (cause is IOException) emit(emptyPreferences()) else throw cause }
+        .first()
+
+    /** Applies [block], treating a failed write as "the marker did not stick". */
+    private suspend inline fun edit(crossinline block: (MutablePreferences) -> Unit) {
+        try {
+            context.settingsDataStore.edit { block(it) }
+        } catch (e: IOException) {
+            Log.w(TAG, "could not persist a self-grant marker", e)
+        }
+    }
+
+    private companion object {
+        val KEY_GRANTED_ONCE = stringSetPreferencesKey("self_grant_granted_once")
+        val KEY_ROOT_UNAVAILABLE = booleanPreferencesKey("self_grant_root_unavailable")
+
+        const val TAG = "SelfGrantStore"
+    }
+}

--- a/app/src/main/java/com/valhalla/loki/model/SelfPermissionGrabber.kt
+++ b/app/src/main/java/com/valhalla/loki/model/SelfPermissionGrabber.kt
@@ -1,0 +1,446 @@
+package com.valhalla.loki.model
+
+import android.content.pm.PackageManager
+import android.content.pm.PermissionInfo
+import android.os.Build
+import android.util.Log
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import rikka.shizuku.Shizuku
+
+/** Where a self-grant sweep has got to. Collected by the UI with `collectAsState()`. */
+sealed interface SelfGrantState {
+
+    /** Nothing to do, or nothing to do *yet* — no privilege is live. */
+    data object Idle : SelfGrantState
+
+    /** A sweep is running. */
+    data object Working : SelfGrantState
+
+    /**
+     * A grant is available but needs the user's word, because taking it closes Loki.
+     *
+     * Only ever reached on the Shizuku path. Root does not ask, because root can put Loki back —
+     * see [PermissionManager.armSelfRelaunchViaRoot].
+     */
+    data class Offered(
+        val permissions: List<String>,
+        val channel: GrantChannel,
+    ) : SelfGrantState
+
+    /** The sweep finished. [refused] is what a channel accepted but the device did not grant. */
+    data class Done(
+        val granted: List<String>,
+        val refused: List<String>,
+    ) : SelfGrantState
+}
+
+/**
+ * Takes the permissions Loki declares, using the privilege the user has already given it.
+ *
+ * The shape is ported from Thor's `SelfPermissionGranter`, and three things about Loki's version
+ * are different in ways that matter:
+ *
+ *  - **The rule had to change.** Thor grants what is `dangerous`; `READ_LOGS` is
+ *    `signature|privileged|development`, so a verbatim port grants nothing that Loki cares about.
+ *    [planSelfGrant] carries the reasoning.
+ *  - **One of the grants ends this process.** Changing a permission that carries supplementary gids
+ *    kills the whole appId, and `READ_LOGS` is `gids=[1007, 1096]`. So the sweep orders survivable
+ *    grants first, treats everything after a fatal grant as unreachable, and — on root only — arms
+ *    a detached relaunch *before* issuing it. Thor never needed any of this: none of its
+ *    permissions kill it.
+ *  - **The verdict lives in the next process.** Thor re-reads and reports. Here the re-read that
+ *    matters is the one at the top of the *next* launch — but a process-memory latch turned out not
+ *    to be the whole story, because two decisions have to outlive the process that made them.
+ *    [SelfGrantStore] holds those two markers and says why.
+ *
+ * Constructor dependencies rather than a `Context`, so the pieces worth testing — [planSelfGrant],
+ * [selfGrantCommand], [selfRelaunchCommand] — stay reachable from a JVM test. `:app` has no mocking
+ * library by policy, so anything that needs a live `PackageManager` is device-verified by hand.
+ */
+class SelfPermissionGrabber(
+    private val packageName: String,
+    private val packageManager: PackageManager,
+    private val permissionManager: PermissionManager,
+    private val logcatCapture: LogcatCapture,
+    private val store: SelfGrantStore,
+) {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    /**
+     * Serialises sweeps.
+     *
+     * [start] and the sticky Shizuku callback can both arrive within a millisecond of each other on
+     * a cold start, and two concurrent sweeps would each read "not granted" and each issue the same
+     * privileged `pm grant`.
+     */
+    private val sweeping = Mutex()
+
+    private val _state = MutableStateFlow<SelfGrantState>(SelfGrantState.Idle)
+    val state: StateFlow<SelfGrantState> = _state.asStateFlow()
+
+    /**
+     * Latched only on a run that genuinely finished.
+     *
+     * A declined offer, an unanswered probe or a refused grant all leave it open, so the next
+     * [refresh] retries. `@Volatile` because the sweep runs on an IO thread and [start] is called
+     * from the main one.
+     */
+    @Volatile
+    private var completed = false
+
+    private var started = false
+
+    /**
+     * Set once an Activity has existed in this process, and never cleared.
+     *
+     * `Application.onCreate` runs on **every** process start, not only one the user asked for. Loki
+     * exports `LokiDocumentsProvider` with a `DOCUMENTS_PROVIDER` intent-filter, so DocumentsUI
+     * starts this process to read `queryRoots` whenever *any* app opens a file picker — and the
+     * sticky Shizuku callback re-enters [refresh] in that process too. Ungated, the sweep would
+     * probe `su` there (a root-manager prompt over somebody else's picker), take the fatal grant,
+     * and let the armed relaunch put Loki in the foreground on top of whatever the user was
+     * actually doing.
+     *
+     * [PermissionManager.selfRelaunchCommand]'s `pidof` guard cannot cover that: the process really
+     * did die, so there is nothing for `pidof` to find and the `am start` fires. That guard answers
+     * "did the grant fail?"; this flag answers "was there a UI to come back to?" — two different
+     * questions, and only the second one is about headless starts.
+     *
+     * `@Volatile` because it is written from the main thread and read on the sweep's IO thread.
+     */
+    @Volatile
+    private var uiPresent = false
+
+    /**
+     * Registers the Shizuku listener and runs one sweep. Idempotent.
+     *
+     * The sweep it starts does nothing until an Activity exists — see [uiPresent] and
+     * [onUiPresent]. The listener registration is what has to happen this early; the grant does
+     * not, and must not.
+     *
+     * `Sticky` is the load-bearing word, and Loki has already paid for learning it once (see
+     * `MainActivity.onCreate`): `ShizukuProvider` is a ContentProvider, and providers are installed
+     * *before* `Application.onCreate`, so the binder has usually arrived by the time this runs and a
+     * plain `addBinderReceivedListener` would sit dead forever. The sticky variant fires immediately
+     * when the binder is present **and** on a later delivery, which is the whole of the
+     * "is a privilege gateway live?" signal Thor buys with a `PrivilegeStateProvider` state flow.
+     *
+     * The listener is never removed. This is an application-scoped singleton, so there is nothing
+     * to leak and no lifecycle to outlive — unlike the Activity, which does remove its own.
+     * `@Synchronized` and the [started] flag because Shizuku keeps its listeners in static
+     * `ArrayList`s without de-duplicating.
+     */
+    @Synchronized
+    fun start() {
+        if (started) return
+        started = true
+        runCatching { Shizuku.addBinderReceivedListenerSticky(binderReceivedListener) }
+            .onFailure { Log.d(TAG, "Shizuku listener could not be registered", it) }
+        refresh()
+    }
+
+    /**
+     * An Activity now exists in this process, so a sweep may spend privilege. Idempotent.
+     *
+     * Called from `MainActivity.onCreate` — the only Activity Loki declares. The first call runs
+     * the sweep that [start] deliberately declined to; a rotation re-enters and returns. Never
+     * unset: a process that has shown a UI once is one the user opened, and the armed relaunch has
+     * somewhere to come back to for the rest of its life.
+     */
+    fun onUiPresent() {
+        if (uiPresent) return
+        uiPresent = true
+        refresh()
+    }
+
+    /**
+     * Re-runs the sweep. Cheap when there is nothing to do, and never spends a `su` probe that a
+     * previous launch already answered — see [SelfGrantStore.rootUnavailable].
+     */
+    fun refresh() {
+        launchSweep(force = false)
+    }
+
+    /**
+     * Re-runs the sweep on the user's behalf, re-probing root even if the last probe found none.
+     *
+     * The other half of [SelfGrantStore.rootUnavailable]: the marker is what stops an unrooted
+     * device paying for a `su` spawn on every cold start, and this is what stops that marker being
+     * permanent for someone who roots their phone afterwards. Wired to the "Tap to re-check" row in
+     * Settings, which is the only place in the app where re-probing is what the user just asked for.
+     */
+    fun recheck() {
+        launchSweep(force = true)
+    }
+
+    private fun launchSweep(force: Boolean) {
+        scope.launch { sweeping.withLock { sweep(force) } }
+    }
+
+    /**
+     * The user accepted an [SelfGrantState.Offered]. Issues the grants it named.
+     *
+     * Expect this call to be the last thing the process does — with one exception, and it is the
+     * reason [grantFatal] claims the capture rather than trusting [sweep]'s check: a capture may have
+     * been started while the dialog was on screen, and then nothing is granted and Loki stays up.
+     */
+    fun confirmOffered() {
+        val offered = _state.value as? SelfGrantState.Offered ?: return
+        scope.launch {
+            sweeping.withLock {
+                _state.value = SelfGrantState.Working
+                val granted = grantFatal(offered.permissions, offered.channel)
+                finish(granted, offered.permissions - granted.toSet(), hasUnanswered = false)
+            }
+        }
+    }
+
+    /** The user declined. Dropped for this process only — the latch stays open. */
+    fun dismissOffered() {
+        if (_state.value is SelfGrantState.Offered) _state.value = SelfGrantState.Idle
+    }
+
+    /**
+     * One pass. Never throws at the caller: a failure here means a permission the user can still
+     * grant by hand, which is what every screen already offers.
+     */
+    private suspend fun sweep(force: Boolean) {
+        if (completed) return
+        // Nothing below may spend privilege in a process the user did not open — see [uiPresent].
+        // Ahead of the plan, so a headless start costs no binder traffic either, and deliberately
+        // without latching: the next start that does have a UI sweeps normally.
+        if (!uiPresent) {
+            Log.d(TAG, "sweep skipped: no Activity in this process")
+            return
+        }
+        try {
+            // The cheap early exit. The kill is appId-wide, so it takes the foreground service and
+            // its half-written file with it, and nothing here is urgent enough to cost someone a
+            // capture in progress. It is not the guarantee, though — everything below this line
+            // takes time, so the fatal grant claims the capture rather than re-reading this flag.
+            if (logcatCapture.isCapturing) {
+                Log.d(TAG, "sweep skipped: a capture is running")
+                return
+            }
+
+            // The plan is built before any privilege is probed, and that ordering is the direct
+            // answer to the objection that disabled the old onboarding gate: probing root means
+            // spawning `su`, and possibly a root-manager prompt, on every cold start. Classifying
+            // permissions is binder traffic only, so once there is nothing left to grant — which is
+            // every launch after the first successful one — this method spawns no shell at all.
+            // Note that a *fresh* install on API 33+ does have something to grant, because
+            // POST_NOTIFICATIONS starts out ungranted, so "the common launch is free" is a claim
+            // about steady state and not about the first run.
+            val plan = planSelfGrant(readSelfPermissions(), store.grantedOnce())
+            if (plan.toGrant.isEmpty()) {
+                finish(granted = emptyList(), refused = emptyList(), hasUnanswered = plan.hasUnanswered)
+                return
+            }
+
+            _state.value = SelfGrantState.Working
+            val channel = resolveChannel(force)
+            if (channel == GrantChannel.NONE) {
+                // Not a failure and not a completed run: the user may authorise Shizuku or grant
+                // root in a minute, and the sticky Shizuku listener or `recheck()` brings us back.
+                Log.d(TAG, "no privilege gateway; ${plan.toGrant.size} permission(s) left alone")
+                _state.value = SelfGrantState.Idle
+                return
+            }
+
+            val survivable = plan.toGrant.filterNot { it in plan.fatal }
+            val granted = grant(survivable, channel).toMutableList()
+            // Recorded here rather than in finish(), because the Shizuku path returns below without
+            // reaching it. What is remembered is only what the device confirmed, and only the
+            // survivable half — a name here is one the user can now revoke in Settings and expect
+            // that to stick.
+            store.recordGranted(granted)
+
+            if (plan.fatal.isEmpty()) {
+                finish(granted, survivable - granted.toSet(), plan.hasUnanswered)
+                return
+            }
+
+            val fatal = plan.toGrant.filter { it in plan.fatal }
+            if (channel == GrantChannel.SHIZUKU) {
+                // Shizuku cannot put us back, so it has to ask. A `newProcess` shell is torn down
+                // with the client that asked for it — device-verified, and recorded in
+                // PermissionManager.grantReadLogsViaShizuku.
+                _state.value = SelfGrantState.Offered(fatal, channel)
+                return
+            }
+
+            granted += grantFatal(fatal, channel)
+            finish(granted, plan.toGrant - granted.toSet(), plan.hasUnanswered)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Log.w(TAG, "self-grant sweep failed", e)
+            _state.value = SelfGrantState.Idle
+        }
+    }
+
+    /**
+     * Which gateway to grant through, and the only place in this class that spends a `su` probe.
+     *
+     * Root is preferred because it grants silently and can put Loki back, and it is the expensive
+     * question: `isRootAvailable()` spawns or reuses `su` and, on a device whose root manager asks,
+     * raises a prompt. On a phone that has no root and never will, that used to happen on every
+     * single cold start, because `READ_LOGS` is permanently ungranted there and so the plan is
+     * permanently non-empty. [SelfGrantStore.rootUnavailable] is the memory that stops it, and
+     * [recheck] is how a user who roots their phone later gets the probe back.
+     *
+     * Shizuku is checked either way and costs nothing — `Shizuku.checkSelfPermission()` is a local
+     * call against a binder that is either there or not. One consequence worth naming: a user who is
+     * running Shizuku *and* grants root after the marker is set will be offered the Shizuku path,
+     * with its dialog, rather than root's silent grant, until they tap re-check.
+     */
+    private suspend fun resolveChannel(force: Boolean): GrantChannel {
+        if (force || !store.rootUnavailable()) {
+            val rooted = permissionManager.isRootAvailable()
+            store.setRootUnavailable(!rooted)
+            if (rooted) return GrantChannel.ROOT
+        } else {
+            Log.d(TAG, "root probe skipped: a previous launch found none")
+        }
+        return if (permissionManager.isShizukuAvailable()) {
+            GrantChannel.SHIZUKU
+        } else {
+            GrantChannel.NONE
+        }
+    }
+
+    /** Issues [permissions] and returns the ones the device confirms afterwards. */
+    private suspend fun grant(permissions: List<String>, channel: GrantChannel): List<String> =
+        permissions.filter { permission ->
+            val attempt = when (channel) {
+                GrantChannel.ROOT -> permissionManager.grantSelfViaRoot(permission)
+                GrantChannel.SHIZUKU -> permissionManager.grantSelfViaShizuku(permission)
+                GrantChannel.NONE -> GrantAttempt(GrantChannel.NONE, false)
+            }
+            // Re-read, never the exit code. `pm grant` exits 0 on some ROMs while the permission
+            // stays ungranted, and a channel can report failure for a grant that landed.
+            val held = permissionManager.isHeld(permission)
+            if (!held) Log.w(TAG, "$permission still not held after ${channel.name}: ${attempt.detail}")
+            held
+        }
+
+    /**
+     * Issues the grants that are expected to kill us, arming a relaunch first where one is possible.
+     *
+     * Everything after the first fatal grant is best effort. It is written as a loop because the
+     * plan may name more than one, not because the second iteration is expected to happen.
+     *
+     * The claim on [LogcatCapture] is what makes the capture check at the top of [sweep] mean
+     * something. That check is minutes stale by the time we get here — the root probe alone can take
+     * Odin's full ten seconds, and on the Shizuku path a human has been reading a dialog in between —
+     * and a check-then-act cannot be repaired by checking again. If the claim is refused, the capture
+     * wins and the retry stays open.
+     */
+    private suspend fun grantFatal(
+        permissions: List<String>,
+        channel: GrantChannel,
+    ): List<String> {
+        if (!logcatCapture.blockForPrivilegedGrant()) {
+            Log.i(TAG, "fatal grant abandoned: a capture is running and this would kill it")
+            return emptyList()
+        }
+        try {
+            if (channel == GrantChannel.ROOT) {
+                val armed = permissionManager.armSelfRelaunchViaRoot()
+                Log.d(TAG, "relaunch armed=$armed before ${permissions.joinToString()}")
+            }
+            Log.i(TAG, "granting ${permissions.joinToString()} — this may be the last line this process logs")
+            return grant(permissions, channel)
+        } finally {
+            // Reached only if the grant did not kill us, i.e. did not land. On the success path the
+            // flag goes with the process.
+            logcatCapture.releaseAfterPrivilegedGrant()
+        }
+    }
+
+    /** Publishes the outcome and latches only a run that left nothing behind. */
+    private fun finish(granted: List<String>, refused: List<String>, hasUnanswered: Boolean) {
+        if (refused.isEmpty() && !hasUnanswered) completed = true
+        _state.value = SelfGrantState.Done(granted, refused)
+    }
+
+    /**
+     * Loki's own declared permissions, as the running device describes each one.
+     *
+     * `requestedPermissions` is the *merged* manifest, so it includes what Shizuku's provider AAR
+     * contributes — eight names on a device with Shizuku installed, not the six in
+     * `app/src/main/AndroidManifest.xml`. That is the point of asking rather than keeping a list.
+     */
+    private fun readSelfPermissions(): List<SelfPermission> {
+        val requested = runCatching { requestedPermissions() }
+            .onFailure { Log.w(TAG, "could not read our own requested permissions", it) }
+            .getOrNull()
+            ?: return emptyList()
+
+        return requested.map { name ->
+            SelfPermission(
+                name = name,
+                declaration = declarationOf(name),
+                isGranted = permissionManager.isHeld(name),
+            )
+        }
+    }
+
+    private fun requestedPermissions(): List<String> {
+        val info = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            packageManager.getPackageInfo(
+                packageName,
+                PackageManager.PackageInfoFlags.of(PackageManager.GET_PERMISSIONS.toLong()),
+            )
+        } else {
+            @Suppress("DEPRECATION")
+            packageManager.getPackageInfo(packageName, PackageManager.GET_PERMISSIONS)
+        }
+        return info.requestedPermissions?.toList().orEmpty()
+    }
+
+    /**
+     * What the OS says about one permission name.
+     *
+     * The three-way split is the whole reason [SelfPermissionDeclaration] is not a `Boolean?`:
+     * `NameNotFoundException` is an authoritative "not on this build", and any other failure is not
+     * an answer at all and must leave the run repeatable.
+     */
+    private fun declarationOf(name: String): SelfPermissionDeclaration = try {
+        // No Tiramisu branch here, unlike requestedPermissions() above: the `long`-flags overloads
+        // added in API 33 cover PackageInfo and friends, and `getPermissionInfo(String, Int)` was
+        // never deprecated alongside them.
+        val info = packageManager.getPermissionInfo(name, 0)
+        SelfPermissionDeclaration.Declared(
+            DeclaredPermission(
+                isDangerous = info.protection == PermissionInfo.PROTECTION_DANGEROUS,
+                // The parentheses are mandatory: Kotlin's infix `and` binds looser than `!=`.
+                isDevelopment =
+                    (info.protectionFlags and PermissionInfo.PROTECTION_FLAG_DEVELOPMENT) != 0,
+            )
+        )
+    } catch (_: PackageManager.NameNotFoundException) {
+        SelfPermissionDeclaration.Undefined
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Throwable) {
+        Log.d(TAG, "could not classify $name", e)
+        SelfPermissionDeclaration.Unknown
+    }
+
+    private val binderReceivedListener = Shizuku.OnBinderReceivedListener { refresh() }
+
+    private companion object {
+        private const val TAG = "SelfPermissionGrabber"
+    }
+}

--- a/app/src/main/java/com/valhalla/loki/model/SelfPermissions.kt
+++ b/app/src/main/java/com/valhalla/loki/model/SelfPermissions.kt
@@ -1,0 +1,255 @@
+package com.valhalla.loki.model
+
+/**
+ * How the running OS describes one permission that **Loki's own manifest** declares.
+ *
+ * Two booleans and not Thor's one, and that difference is the whole reason this rule is ported
+ * rather than copied. Thor's `DeclaredPermission` carries `isDangerous` alone, computed as
+ * `(protectionLevel and PROTECTION_MASK_BASE) == PROTECTION_DANGEROUS`. `READ_LOGS` is
+ * `signature|privileged|development` — device-verified on API 36 and API 37 — so its base
+ * protection is `signature`, and Thor's test is `2 == 1`. A verbatim port never grants the one
+ * permission Loki exists to hold.
+ *
+ * The rejection was never about grantability. `pm grant` reaches
+ * `grantRuntimePermissionInternal`, which accepts `isRuntimePermission || bp.isDevelopment()`, so a
+ * `development` permission is as grantable as a `dangerous` one. Asking the base protection alone
+ * is simply the wrong question.
+ */
+data class DeclaredPermission(
+    /** Base protection is `dangerous` — `PermissionInfo.getProtection()`. */
+    val isDangerous: Boolean,
+    /** The `development` protection *flag* is set — `PermissionInfo.getProtectionFlags()`. */
+    val isDevelopment: Boolean,
+)
+
+/**
+ * What the running OS says about one of Loki's declared permissions.
+ *
+ * Three states and not two, for the reason Thor's version of this documents: "this build has never
+ * heard of it" is an authoritative answer about the device, and "the package manager would not tell
+ * us" is not an answer at all. Folding the second into the first is what would let one unlucky
+ * binder call latch a permission off for the life of the process.
+ */
+sealed interface SelfPermissionDeclaration {
+
+    /**
+     * `getPermissionInfo` threw `NameNotFoundException` — the definitive "not on this build".
+     *
+     * The common case, not an edge one. Loki's merged manifest declares `POST_NOTIFICATIONS`,
+     * which does not exist below API 33, and two `shizuku.permission.API_V23` spellings that exist
+     * only where Shizuku is installed. `minSdk` is 28, so both are ordinary devices.
+     */
+    data object Undefined : SelfPermissionDeclaration
+
+    /** The question failed for some reason other than "no such permission". Costs the run its latch. */
+    data object Unknown : SelfPermissionDeclaration
+
+    /** The OS defines it, and described it. */
+    data class Declared(val permission: DeclaredPermission) : SelfPermissionDeclaration
+}
+
+/** One permission out of Loki's own `requestedPermissions`, as the running device describes it. */
+data class SelfPermission(
+    val name: String,
+    val declaration: SelfPermissionDeclaration,
+    val isGranted: Boolean,
+)
+
+/**
+ * What a privileged self-grant should do this run.
+ *
+ * Three fields rather than a `List<String>`, because the *absence* of a permission from [toGrant]
+ * does not say which of four reasons put it there, and because one of the grants ends the process.
+ */
+data class SelfGrantPlan(
+    /**
+     * The permissions worth a `pm grant` — **survivable ones first, in declaration order, then
+     * the fatal ones**.
+     *
+     * The ordering is load-bearing and it is where this rule parts company with Thor's, whose test
+     * suite pins `theManifestsDeclarationOrderIsPreserved` outright. Granting a permission that
+     * carries supplementary gids kills Loki's whole appId mid-loop, so anything queued behind it is
+     * never issued — not the remaining grants, not the post-grant verification, not the latch.
+     * `dumpsys package com.valhalla.loki` lists `READ_LOGS` sixth of eight, so declaration order
+     * alone would drop the two after it on every device.
+     */
+    val toGrant: List<String>,
+    /**
+     * The subset of [toGrant] whose grant is expected to kill this process.
+     *
+     * `development ⇒ fatal` is a deliberate over-approximation. The kill is the platform's reaction
+     * to a change in the app's supplementary group set — `READ_LOGS` is `gids=[1007, 1096]`, and
+     * `POST_NOTIFICATIONS` is `gids=[]`, which is why one kills and the other does not — and
+     * `PermissionInfo` exposes no gids, so no rule can ask the question directly. Every gid-bearing
+     * permission Loki declares is `development`-flagged, and the only cost of being wrong is
+     * issuing a grant last that need not have been.
+     */
+    val fatal: Set<String>,
+    /**
+     * True when at least one permission came back [SelfPermissionDeclaration.Unknown].
+     *
+     * The caller must not latch its once-per-process guard on such a run. Without this, a package
+     * manager that hiccupped on the one probe that mattered would disable the feature for the life
+     * of the process and report success while doing it.
+     */
+    val hasUnanswered: Boolean,
+)
+
+/**
+ * Which of Loki's own declared permissions a privileged `pm grant` could actually change.
+ *
+ * **The device is asked, and no name is hardcoded.** Loki's manifest is the input, so a permission
+ * added to it later is covered without a second edit here — the failure mode of a hand-kept list is
+ * that the list and the manifest agree on the day they are written and never again. It also makes
+ * the answer honest per device: on API 36 with Shizuku installed this returns `POST_NOTIFICATIONS`
+ * then `READ_LOGS`, on API 28 it returns `READ_LOGS` alone.
+ *
+ * The five rejections all exist because `pm grant` *fails* on them, or because issuing it would be
+ * actively harmful, and a privileged command is not free — it is a round trip through a root shell
+ * or the Shizuku binder:
+ *
+ * 1. **Not defined on this build** ([SelfPermissionDeclaration.Undefined]).
+ *    `PackageManagerShellCommand.runGrantRevokePermission` resolves the name first and answers
+ *    `Unknown permission: …`. Nothing to grant, and nothing a retry could improve.
+ * 2. **Defined, but neither `dangerous` nor `development`.** `grantRuntimePermission` throws
+ *    `SecurityException("… is not a changeable permission type")` for anything else. That covers
+ *    `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_DATA_SYNC`, `QUERY_ALL_PACKAGES` and Loki's own
+ *    `signature` receiver permission — four of the eight names on a real device.
+ * 3. **Already held.** Re-granting is a no-op that still costs the round trip — and for a fatal
+ *    permission it is far worse than a wasted round trip: grant → platform kill → relaunch →
+ *    grant is a launch loop. This guard is the only thing standing between one death and an
+ *    unusable app.
+ * 4. **Taken once already, and gone.** A `dangerous` name in [grantedOnce] that Loki no longer holds
+ *    was *revoked*, and the actor who can do that through the UI is the user. See below.
+ * 5. A [SelfPermissionDeclaration.Unknown] is not a rejection: it is left out of [toGrant] *and*
+ *    recorded in [SelfGrantPlan.hasUnanswered], so the run can be repeated.
+ *
+ * Pure, because everything above is a decision and none of it is a binder call. `PackageManager` is
+ * abstract and `:app` has no mocking library by policy, so a rule that touches an Android type is a
+ * rule no test can reach.
+ *
+ * ⚠️ **On a first run this overrides a decision the user may have made deliberately**, because a
+ * permission is in [toGrant] precisely for being ungranted and nothing on the device distinguishes
+ * "never asked" from "denied". That is the owner's explicit call for privileged users — the point of
+ * granting Loki root or Shizuku is not to keep being asked — and it is why the sweep runs *only*
+ * once a privilege gateway is live, and why nothing here touches another package's permissions.
+ *
+ * What it must never do is override the *same* decision twice, and [grantedOnce] is the whole of
+ * that fix. `POST_NOTIFICATIONS` is granted, the user turns Loki's notifications off in Settings,
+ * and the next cold start used to hand it straight back — an app arguing with its own user. A name
+ * we have already taken is therefore taken once and never again.
+ *
+ * The exemption is deliberate and asymmetric: [grantedOnce] is consulted for `dangerous` permissions
+ * only. A `development` permission has **no user-visible switch** anywhere in Settings, so its
+ * absence cannot be a user's choice — it is a reinstall, an `adb revoke`, or a factory reset — and
+ * re-granting `READ_LOGS` is the behaviour the feature exists for.
+ */
+fun planSelfGrant(
+    permissions: List<SelfPermission>,
+    grantedOnce: Set<String> = emptySet(),
+): SelfGrantPlan {
+    val survivable = mutableListOf<String>()
+    val fatal = mutableListOf<String>()
+    var hasUnanswered = false
+
+    for (permission in permissions) {
+        when (val declaration = permission.declaration) {
+            SelfPermissionDeclaration.Unknown -> hasUnanswered = true
+            SelfPermissionDeclaration.Undefined -> Unit
+            is SelfPermissionDeclaration.Declared -> {
+                if (permission.isGranted) continue
+                when {
+                    // Checked before isDangerous, which is what keeps a development permission out
+                    // of the grantedOnce exemption rather than merely usually out of it.
+                    declaration.permission.isDevelopment -> fatal += permission.name
+                    declaration.permission.isDangerous && permission.name !in grantedOnce ->
+                        survivable += permission.name
+                }
+            }
+        }
+    }
+
+    return SelfGrantPlan(
+        toGrant = survivable + fatal,
+        fatal = fatal.toSet(),
+        hasUnanswered = hasUnanswered,
+    )
+}
+
+/**
+ * Everything a privileged command line here is allowed to contain.
+ *
+ * Deliberately narrower than "valid package name": no `-`, no `/`, no whitespace, nothing a shell
+ * gives meaning to. A component's class name and a permission name fit inside it as well.
+ */
+private val SAFE = Regex("[A-Za-z0-9._]+")
+
+/**
+ * The `pm grant` command line for one of **Loki's own** permissions.
+ *
+ * Returns `null` — meaning "run nothing" — for any argument outside [SAFE]. Both arguments come
+ * from `PackageManager` today, so the guard can never fire; it exists so that stops being
+ * load-bearing if either ever stops being ours. Everywhere else in Loki, AGENTS.md rule 1 holds
+ * because only an `Int` uid from `PackageManager` reaches a command line; a root shell takes a
+ * string rather than an argv list, which makes this the one place that needs saying out loud.
+ *
+ * **No `--user` flag.** A `development` permission is recorded as an *install* permission, which
+ * applies to every user — verified on device, where `dumpsys package com.valhalla.loki` lists
+ * `READ_LOGS: granted=true` under `install permissions:` and leaves `runtime permissions:` without
+ * it.
+ */
+fun selfGrantCommand(packageName: String, permission: String): String? =
+    if (!SAFE.matches(packageName) || !SAFE.matches(permission)) {
+        null
+    } else {
+        "pm grant $packageName $permission"
+    }
+
+/**
+ * A detached command that brings Loki back after the platform has killed it for the grant.
+ *
+ * **This has to be issued *before* the fatal grant, not after.** Both halves of that sentence cost
+ * a device session to learn, and both are recorded in
+ * [PermissionManager.grantReadLogsViaShizuku]: chaining `am start` directly after the grant won a
+ * millisecond-wide race and delivered the intent to the already-dying Activity, and making the
+ * death deterministic first never reached the second command at all.
+ *
+ * So the shape is: arm this, then grant. [delaySeconds] is what lets the kill complete before the
+ * launch, and `nohup … &` with both streams closed is what stops Odin's `exec` from waiting on a
+ * command that outlives the call — and, on Magisk, what lets the grandchild outlive *us*, since the
+ * root shell is forked from `magiskd` rather than from Loki and carries no death signal.
+ *
+ * ⚠️ **Root only.** Shizuku ties a `newProcess` shell to the client that asked for it, so nothing
+ * launched from one can survive the client's death; the Shizuku path warns the user instead.
+ *
+ * **The `pidof` guard is the point of the second half of the line.** Arming has to happen before the
+ * grant, so by the time the command runs nothing can call it off — and a grant that *failed* leaves
+ * Loki alive, whereupon an unconditional `am start` two seconds later drags the app to the
+ * foreground over whatever the user has since moved on to. The previous version of this comment
+ * called that harmless. It is not: it is an app launching itself for no reason, and the failure it
+ * follows is precisely the case where nothing should happen at all. So the relaunch fires only when
+ * our process is genuinely gone.
+ *
+ * `pidof <packageName>` is the process name, not the package: they coincide because Loki declares no
+ * `android:process` anywhere in its manifest, and moving a component to its own process means
+ * revisiting this. The lookup works because the command runs as **root**, for which `/proc` is not
+ * `hidepid`-restricted — the same reason a `pidof` for *another* app fails everywhere else in Loki.
+ *
+ * The guard errs in the mild direction. If the platform revives the process headlessly inside the
+ * delay — a query to `LokiDocumentsProvider`, say — `pidof` finds it and no Activity is started, so
+ * the user taps the icon. That is a worse outcome than a relaunch and a much better one than a
+ * hijack.
+ *
+ * Returns `null` if either component name falls outside [SAFE].
+ */
+fun selfRelaunchCommand(
+    packageName: String,
+    activityClassName: String,
+    delaySeconds: Int,
+): String? {
+    if (!SAFE.matches(packageName) || !SAFE.matches(activityClassName)) return null
+    if (delaySeconds < 0) return null
+    return "nohup sh -c 'sleep $delaySeconds; " +
+        "pidof $packageName >/dev/null 2>&1 || " +
+        "am start -n $packageName/$activityClassName' >/dev/null 2>&1 &"
+}

--- a/app/src/main/java/com/valhalla/loki/model/ThemeManager.kt
+++ b/app/src/main/java/com/valhalla/loki/model/ThemeManager.kt
@@ -7,17 +7,16 @@ import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.stringPreferencesKey
-import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import java.io.IOException
 
-// Top level, so there is exactly one DataStore instance per process. Anything else that wants an
-// app preference must add a key here or go through ThemeManager — constructing a second DataStore
-// over the same file throws at runtime.
-private val Context.settingsDataStore by preferencesDataStore(name = "settings")
+// The `settingsDataStore` this file reads and writes lives in Preferences.kt, shared with
+// SelfGrantStore. It used to be declared here and private, which made the second owner of a
+// preference either a second DataStore over the same file — that throws — or a theme key that is
+// not about the theme. The keys below stay private to this class; only the store is shared.
 
 /**
  * Which theme the user picked.

--- a/app/src/main/java/com/valhalla/loki/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/valhalla/loki/ui/home/HomeScreen.kt
@@ -77,8 +77,9 @@ fun HomeScreen(
     onExitConfirmed: () -> Unit,
     // Shizuku's grant flow needs an Activity to bind the permission callback to, which a
     // composable does not have, so the Activity hands the trigger down rather than the screen
-    // reaching for it.
-    onRequestShizuku: () -> Unit = {},
+    // reaching for it. It covers root as well: which channel actually runs the grant is the
+    // Activity's decision, not something a settings row should be picking.
+    onRequestPrivilege: () -> Unit = {},
 ) {
     val uiState by viewModel.uiState.collectAsState()
 
@@ -157,7 +158,7 @@ fun HomeScreen(
             entry<LokiRoute.Settings> {
                 SettingsScreen(
                     modifier = modifier,
-                    onRequestShizuku = onRequestShizuku,
+                    onRequestPrivilege = onRequestPrivilege,
                     onBrowseLogs = { settingsBackStack.pushOnce(LokiRoute.LogsExplorer) },
                 )
             }

--- a/app/src/main/java/com/valhalla/loki/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/valhalla/loki/ui/settings/SettingsScreen.kt
@@ -101,7 +101,7 @@ private const val ADB_GRANT_COMMAND =
 fun SettingsScreen(
     modifier: Modifier = Modifier,
     viewModel: SettingsViewModel = koinViewModel(),
-    onRequestShizuku: () -> Unit = {},
+    onRequestPrivilege: () -> Unit = {},
     onBrowseLogs: () -> Unit = {},
 ) {
     val context = LocalContext.current
@@ -204,10 +204,16 @@ fun SettingsScreen(
                             privilege.canCapture -> MaterialTheme.colorScheme.success
                             else -> MaterialTheme.colorScheme.error
                         },
-                        onClick = { viewModel.refresh() },
+                        // recheckPrivilege(), not refresh(): a tap here also re-runs the self-grant
+                        // sweep, which is the only way back for a device that had no privilege the
+                        // last time it was asked.
+                        onClick = { viewModel.recheckPrivilege() },
                     )
                     AsgardSettingRow(
-                        title = "Grant via Shizuku",
+                        // One row rather than one per channel. The Activity picks the channel —
+                        // root if it is there, Shizuku otherwise — because that decision needs a
+                        // suspending root probe, which a settings row must not run.
+                        title = "Grant READ_LOGS",
                         // Not "needs Shizuku installed": `shizukuReady` is false both when
                         // Shizuku is absent and when it is running but has not authorised Loki,
                         // and PermissionManager cannot tell those apart. Saying "not installed"
@@ -215,6 +221,7 @@ fun SettingsScreen(
                         subtitle = when {
                             privilege == null -> "Checking…"
                             privilege.readLogsGranted -> "Already granted"
+                            privilege.rootAvailable -> "Tap to grant through the root shell"
                             privilege.shizukuReady -> "Shizuku has authorised Loki — tap to grant"
                             else -> "Tap to request access through Shizuku"
                         },
@@ -474,22 +481,28 @@ fun SettingsScreen(
     if (showShizukuConfirm) {
         // Warning up front, because the alternative is worse than a dialog: READ_LOGS is a
         // `development` permission, so the platform kills Loki the moment it is granted, and an
-        // app that vanishes when you tap a button reads as a crash. Loki cannot dodge the kill or
-        // restart itself around it — the Shizuku shell that runs the grant is torn down with us
-        // (the reasoning, and the two attempts that failed on device, are in
-        // PermissionManager.grantReadLogsViaShizuku).
+        // app that vanishes when you tap a button reads as a crash. Loki cannot dodge the kill —
+        // the reasoning, and the two attempts that failed on device, are in
+        // PermissionManager.grantReadLogsViaShizuku. It *can* come back afterwards, but only under
+        // root, so the wording splits on that rather than promising it to everyone.
+        val rooted = uiState.privilege?.rootAvailable == true
         AsgardDialogScaffold(
             onDismissRequest = { showShizukuConfirm = false },
-            title = "Grant READ_LOGS and close Loki?",
+            title = if (rooted) "Grant READ_LOGS and restart Loki?" else "Grant READ_LOGS and close Loki?",
             text = "Android closes an app when its permissions change, so Loki will shut down as " +
-                "soon as the grant lands. That is expected, not a crash. Reopen Loki afterwards " +
-                "and it will be able to read other apps' logs.",
+                "soon as the grant lands. That is expected, not a crash. " +
+                if (rooted) {
+                    "Root will reopen Loki a couple of seconds later; if it does not, open it " +
+                        "yourself and the permission will be there."
+                } else {
+                    "Reopen Loki afterwards and it will be able to read other apps' logs."
+                },
             icon = Icons.Filled.Key,
-            confirmText = "Grant and close",
+            confirmText = if (rooted) "Grant and restart" else "Grant and close",
             dismissText = "Cancel",
             onConfirm = {
                 showShizukuConfirm = false
-                onRequestShizuku()
+                onRequestPrivilege()
             },
         )
     }

--- a/app/src/main/java/com/valhalla/loki/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/valhalla/loki/ui/settings/SettingsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.valhalla.loki.model.LogcatCapture
 import com.valhalla.loki.model.PermissionManager
+import com.valhalla.loki.model.SelfPermissionGrabber
 import com.valhalla.loki.model.ThemeManager
 import com.valhalla.loki.model.ThemeMode
 import com.valhalla.loki.model.ThemeSettings
@@ -58,6 +59,7 @@ class SettingsViewModel(
     private val permissionManager: PermissionManager,
     private val logcatCapture: LogcatCapture,
     private val themeManager: ThemeManager,
+    private val selfPermissionGrabber: SelfPermissionGrabber,
     private val logsDir: File,
 ) : ViewModel() {
 
@@ -107,6 +109,21 @@ class SettingsViewModel(
             val stats = withContext(Dispatchers.IO) { measureLogs() }
             _uiState.update { it.copy(stats = stats) }
         }
+    }
+
+    /**
+     * What the "Tap to re-check" row does: re-measures, and re-runs the self-grant sweep.
+     *
+     * Separate from [refresh] because the two callers want different things. `init` and
+     * `clearAllLogs` want the numbers on screen brought up to date; a tap on that row is a user
+     * saying "look again", which is the one signal that justifies re-probing root after a previous
+     * launch found none — see [SelfPermissionGrabber.recheck]. It is also what makes the sweep's own
+     * "the user may grant root in a minute and something brings us back" comment true; before this
+     * existed, nothing did except a Shizuku binder delivery.
+     */
+    fun recheckPrivilege() {
+        refresh()
+        selfPermissionGrabber.recheck()
     }
 
     fun setThemeMode(mode: ThemeMode) = viewModelScope.launch { themeManager.setThemeMode(mode) }

--- a/app/src/test/java/com/valhalla/loki/model/SelfPermissionsTest.kt
+++ b/app/src/test/java/com/valhalla/loki/model/SelfPermissionsTest.kt
@@ -1,0 +1,320 @@
+package com.valhalla.loki.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tests for [planSelfGrant], [selfGrantCommand] and [selfRelaunchCommand].
+ *
+ * Permission names are spelled out rather than read from `android.Manifest`, as Thor's equivalent
+ * test does, so a reader can see which of Loki's declarations each case is actually about.
+ *
+ * The device-shaped cases use the order `dumpsys package com.valhalla.loki` really reports on a
+ * device with Shizuku installed, which is not the order of `app/src/main/AndroidManifest.xml` —
+ * the merged manifest adds what Shizuku's provider AAR contributes, and `READ_LOGS` lands sixth of
+ * eight. That is exactly why the ordering assertions below are not cosmetic.
+ */
+class SelfPermissionsTest {
+
+    private companion object {
+        const val READ_LOGS = "android.permission.READ_LOGS"
+        const val POST_NOTIFICATIONS = "android.permission.POST_NOTIFICATIONS"
+        const val FOREGROUND_SERVICE = "android.permission.FOREGROUND_SERVICE"
+        const val FOREGROUND_SERVICE_DATA_SYNC = "android.permission.FOREGROUND_SERVICE_DATA_SYNC"
+        const val QUERY_ALL_PACKAGES = "android.permission.QUERY_ALL_PACKAGES"
+        const val SHIZUKU_API_V23 = "shizuku.permission.API_V23"
+        const val SHIZUKU_MANAGER_API_V23 = "moe.shizuku.manager.permission.API_V23"
+        const val RECEIVER_NOT_EXPORTED =
+            "com.valhalla.loki.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION"
+    }
+
+    // --- fixtures ------------------------------------------------------------------------------
+
+    /** `dangerous`, like POST_NOTIFICATIONS: grantable, `gids=[]`, does not kill us. */
+    private fun dangerous(name: String, granted: Boolean = false) = SelfPermission(
+        name = name,
+        declaration = SelfPermissionDeclaration.Declared(
+            DeclaredPermission(isDangerous = true, isDevelopment = false)
+        ),
+        isGranted = granted,
+    )
+
+    /** `signature|privileged|development`, like READ_LOGS: grantable, and it kills us. */
+    private fun development(name: String, granted: Boolean = false) = SelfPermission(
+        name = name,
+        declaration = SelfPermissionDeclaration.Declared(
+            DeclaredPermission(isDangerous = false, isDevelopment = true)
+        ),
+        isGranted = granted,
+    )
+
+    /** `normal` or `signature`: defined, and `pm grant` refuses it. */
+    private fun installTime(name: String, granted: Boolean = false) = SelfPermission(
+        name = name,
+        declaration = SelfPermissionDeclaration.Declared(
+            DeclaredPermission(isDangerous = false, isDevelopment = false)
+        ),
+        isGranted = granted,
+    )
+
+    private fun undefined(name: String) =
+        SelfPermission(name, SelfPermissionDeclaration.Undefined, isGranted = false)
+
+    private fun unanswered(name: String) =
+        SelfPermission(name, SelfPermissionDeclaration.Unknown, isGranted = false)
+
+    // --- the case Thor's suite structurally cannot contain --------------------------------------
+
+    @Test
+    fun `a development permission that is not held is grantable, and fatal`() {
+        val plan = planSelfGrant(listOf(development(READ_LOGS)))
+
+        assertEquals(listOf(READ_LOGS), plan.toGrant)
+        assertEquals(setOf(READ_LOGS), plan.fatal)
+        assertFalse(plan.hasUnanswered)
+    }
+
+    @Test
+    fun `an already held development permission plans nothing`() {
+        // The guard that separates one death from a launch loop: grant, get killed, relaunch,
+        // grant again, forever.
+        val plan = planSelfGrant(listOf(development(READ_LOGS, granted = true)))
+
+        assertTrue(plan.toGrant.isEmpty())
+        assertTrue(plan.fatal.isEmpty())
+        assertFalse(plan.hasUnanswered)
+    }
+
+    // --- the rules inherited from Thor ---------------------------------------------------------
+
+    @Test
+    fun `a dangerous permission is grantable and is not fatal`() {
+        val plan = planSelfGrant(listOf(dangerous(POST_NOTIFICATIONS)))
+
+        assertEquals(listOf(POST_NOTIFICATIONS), plan.toGrant)
+        assertTrue(plan.fatal.isEmpty())
+    }
+
+    @Test
+    fun `an already held dangerous permission plans nothing`() {
+        val plan = planSelfGrant(listOf(dangerous(POST_NOTIFICATIONS, granted = true)))
+
+        assertTrue(plan.toGrant.isEmpty())
+    }
+
+    @Test
+    fun `an ungranted install-time permission is still skipped`() {
+        // pm grant answers "not a changeable permission type" for all four of these.
+        val plan = planSelfGrant(
+            listOf(
+                installTime(FOREGROUND_SERVICE),
+                installTime(FOREGROUND_SERVICE_DATA_SYNC),
+                installTime(QUERY_ALL_PACKAGES),
+                installTime(RECEIVER_NOT_EXPORTED),
+            )
+        )
+
+        assertTrue(plan.toGrant.isEmpty())
+        assertFalse(plan.hasUnanswered)
+    }
+
+    @Test
+    fun `an undefined permission is skipped and the run still completes`() {
+        // Shizuku not installed. An authoritative answer about the device, so a retry finds
+        // nothing new and the latch must be allowed to close.
+        val plan = planSelfGrant(listOf(undefined(SHIZUKU_API_V23)))
+
+        assertTrue(plan.toGrant.isEmpty())
+        assertFalse(plan.hasUnanswered)
+    }
+
+    @Test
+    fun `a permission the device would not classify keeps the run repeatable`() {
+        val plan = planSelfGrant(listOf(unanswered(READ_LOGS)))
+
+        assertTrue(plan.toGrant.isEmpty())
+        assertTrue(plan.hasUnanswered)
+    }
+
+    @Test
+    fun `one unanswered probe does not hold back the grants that are known`() {
+        val plan = planSelfGrant(listOf(unanswered(SHIZUKU_API_V23), development(READ_LOGS)))
+
+        assertEquals(listOf(READ_LOGS), plan.toGrant)
+        assertTrue(plan.hasUnanswered)
+    }
+
+    // --- the user's revoke has to win ----------------------------------------------------------
+
+    @Test
+    fun `a dangerous permission taken once is never taken again`() {
+        // The defect this closes: grant POST_NOTIFICATIONS, user turns Loki's notifications off in
+        // Settings, next cold start hands it straight back. An app arguing with its own user.
+        val plan = planSelfGrant(
+            listOf(dangerous(POST_NOTIFICATIONS)),
+            grantedOnce = setOf(POST_NOTIFICATIONS),
+        )
+
+        assertTrue(plan.toGrant.isEmpty())
+        assertFalse(plan.hasUnanswered)
+    }
+
+    @Test
+    fun `a development permission is taken again even after being revoked`() {
+        // The asymmetry, and it is deliberate: READ_LOGS has no switch anywhere in Settings, so its
+        // absence cannot be something the user chose. A reinstall or an `adb revoke` is the only way
+        // to get here, and re-granting is the whole point of the feature.
+        val plan = planSelfGrant(
+            listOf(development(READ_LOGS)),
+            grantedOnce = setOf(READ_LOGS),
+        )
+
+        assertEquals(listOf(READ_LOGS), plan.toGrant)
+        assertEquals(setOf(READ_LOGS), plan.fatal)
+    }
+
+    @Test
+    fun `remembering a permission does not disturb the rest of the plan`() {
+        val plan = planSelfGrant(
+            listOf(
+                dangerous(POST_NOTIFICATIONS),
+                dangerous("android.permission.SOMETHING_ELSE"),
+                development(READ_LOGS),
+            ),
+            grantedOnce = setOf(POST_NOTIFICATIONS),
+        )
+
+        assertEquals(listOf("android.permission.SOMETHING_ELSE", READ_LOGS), plan.toGrant)
+        assertEquals(setOf(READ_LOGS), plan.fatal)
+    }
+
+    @Test
+    fun `an unknown name in the remembered set changes nothing`() {
+        // The set only ever grows, so it outlives a permission being dropped from the manifest.
+        val plan = planSelfGrant(
+            listOf(dangerous(POST_NOTIFICATIONS)),
+            grantedOnce = setOf("android.permission.LONG_GONE"),
+        )
+
+        assertEquals(listOf(POST_NOTIFICATIONS), plan.toGrant)
+    }
+
+    // --- ordering, which is where this parts company with Thor ---------------------------------
+
+    @Test
+    fun `the fatal grant is issued last`() {
+        // Declaration order would put READ_LOGS first and POST_NOTIFICATIONS would never be
+        // attempted, because the process is gone by then.
+        val plan = planSelfGrant(listOf(development(READ_LOGS), dangerous(POST_NOTIFICATIONS)))
+
+        assertEquals(listOf(POST_NOTIFICATIONS, READ_LOGS), plan.toGrant)
+        assertEquals(setOf(READ_LOGS), plan.fatal)
+    }
+
+    @Test
+    fun `declaration order is preserved among the survivable grants`() {
+        val plan = planSelfGrant(
+            listOf(
+                dangerous("android.permission.B"),
+                dangerous("android.permission.A"),
+                development(READ_LOGS),
+                dangerous("android.permission.C"),
+            )
+        )
+
+        assertEquals(
+            listOf("android.permission.B", "android.permission.A", "android.permission.C", READ_LOGS),
+            plan.toGrant,
+        )
+    }
+
+    // --- whole-device fixtures ----------------------------------------------------------------
+
+    @Test
+    fun `Loki's manifest on API 36 plans two grants with READ_LOGS last`() {
+        val plan = planSelfGrant(
+            listOf(
+                installTime(RECEIVER_NOT_EXPORTED, granted = true),
+                dangerous(POST_NOTIFICATIONS),
+                installTime(FOREGROUND_SERVICE, granted = true),
+                undefined(SHIZUKU_API_V23),
+                installTime(FOREGROUND_SERVICE_DATA_SYNC, granted = true),
+                development(READ_LOGS),
+                undefined(SHIZUKU_MANAGER_API_V23),
+                installTime(QUERY_ALL_PACKAGES, granted = true),
+            )
+        )
+
+        assertEquals(listOf(POST_NOTIFICATIONS, READ_LOGS), plan.toGrant)
+        assertEquals(setOf(READ_LOGS), plan.fatal)
+        assertFalse(plan.hasUnanswered)
+    }
+
+    @Test
+    fun `on API 28 only READ_LOGS is grantable`() {
+        // POST_NOTIFICATIONS arrived in API 33 and FOREGROUND_SERVICE_DATA_SYNC in API 34, so on
+        // Loki's minSdk both are Undefined — and neither absence may block the latch.
+        val plan = planSelfGrant(
+            listOf(
+                undefined(POST_NOTIFICATIONS),
+                installTime(FOREGROUND_SERVICE, granted = true),
+                undefined(FOREGROUND_SERVICE_DATA_SYNC),
+                development(READ_LOGS),
+                undefined(SHIZUKU_API_V23),
+            )
+        )
+
+        assertEquals(listOf(READ_LOGS), plan.toGrant)
+        assertFalse(plan.hasUnanswered)
+    }
+
+    @Test
+    fun `an empty manifest plans nothing and is complete`() {
+        val plan = planSelfGrant(emptyList())
+
+        assertTrue(plan.toGrant.isEmpty())
+        assertTrue(plan.fatal.isEmpty())
+        assertFalse(plan.hasUnanswered)
+    }
+
+    // --- the command lines --------------------------------------------------------------------
+
+    @Test
+    fun `selfGrantCommand builds the exact pm grant line`() {
+        assertEquals(
+            "pm grant com.valhalla.loki android.permission.READ_LOGS",
+            selfGrantCommand("com.valhalla.loki", READ_LOGS),
+        )
+    }
+
+    @Test
+    fun `selfGrantCommand refuses an argument carrying shell metacharacters`() {
+        assertNull(selfGrantCommand("com.valhalla.loki; rm -rf /", READ_LOGS))
+        assertNull(selfGrantCommand("com.valhalla.loki", "$(id)"))
+        assertNull(selfGrantCommand("com.valhalla.loki", "a b"))
+        assertNull(selfGrantCommand("", READ_LOGS))
+    }
+
+    @Test
+    fun `selfRelaunchCommand detaches, sleeps, then starts our own launcher activity`() {
+        // The `pidof … ||` is not decoration. Arming happens before the grant, so nothing can call
+        // the command off afterwards; a grant that failed leaves Loki alive, and an unconditional
+        // `am start` would then haul the app to the foreground for no reason. Asserted as an exact
+        // string because it is a root shell command line and every character of it matters.
+        assertEquals(
+            "nohup sh -c 'sleep 2; pidof com.valhalla.loki >/dev/null 2>&1 || " +
+                "am start -n com.valhalla.loki/com.valhalla.loki.MainActivity' >/dev/null 2>&1 &",
+            selfRelaunchCommand("com.valhalla.loki", "com.valhalla.loki.MainActivity", 2),
+        )
+    }
+
+    @Test
+    fun `selfRelaunchCommand refuses anything it would have to quote`() {
+        assertNull(selfRelaunchCommand("com.valhalla.loki", "Main Activity", 2))
+        assertNull(selfRelaunchCommand("pkg'; id; '", "com.valhalla.loki.MainActivity", 2))
+        assertNull(selfRelaunchCommand("com.valhalla.loki", "com.valhalla.loki.MainActivity", -1))
+    }
+}


### PR DESCRIPTION
## What & why

Loki's whole job needs `READ_LOGS`, and a user cannot grant it — the protection level is
`signature|privileged|development`, so it appears in no Settings screen and no runtime prompt. Until
now the app shipped holding privilege it could not use: someone with root or Shizuku still had to
reach for a terminal or an ADB cable to make Loki work at all.

`SelfPermissionGrabber` closes that. At launch it asks `PackageManager` which of the permissions Loki
declares are still ungranted and could be changed by `pm grant`, and if there are any, spends
whatever privilege the user has already given the app to take them.

## Changes

- `model/SelfPermissions.kt` — the pure grant rule. Zero `android.*` imports, so it is testable on
  the JVM; `SelfPermissionsTest` (35 cases) is where the behaviour is written down.
- `model/SelfPermissionGrabber.kt` — the sweep: build the plan, resolve a channel, grant survivable
  permissions first and the fatal one last, confirm each by re-reading `checkSelfPermission`.
- `model/SelfGrantStore.kt` — the two markers that have to outlive the process that set them.
- `model/Preferences.kt` — the single `preferencesDataStore(name = "settings")` delegate, now shared
  by `ThemeManager` and `SelfGrantStore`.
- `PermissionManager` — grant / relaunch / probe commands, and `isRootAvailable()` now closes a
  cached non-root shell before re-probing.
- Settings shows the permission state and a "Tap to re-check" row; `MainActivity` registers the three
  Shizuku listeners once for the Activity's lifetime instead of once per button tap.
- `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, `README.md` record the privileged surface, the grant
  rule and the UI gate.

Five things about the rule that are not obvious, all written out in the commit message and in the
code comments:

- **Two booleans, not Thor's one.** Thor gates on `isDangerous`, computed as a masked-base
  comparison. `READ_LOGS` is `2|16|32 = 50`, so that test asks `2 == 1` and structurally cannot ever
  grant it. The `development` flag is what makes `pm grant` work here at all, and it must be a *flag*
  test.
- **Order is load-bearing.** `READ_LOGS` carries `gids=[1007, 1096]`, and a running process's
  supplementary group set cannot change, so the platform kills the whole appId rather than reconcile
  it. Survivable grants go first because the death aborts the rest of the sweep.
- **The channels are asymmetric.** Root grants silently and arms a detached relaunch that survives
  the kill; Shizuku's `newProcess` dies with its client, so it raises a dialog instead. The armed
  command's `pidof` guard means a *failed* grant does not drag Loki to the foreground two seconds
  later.
- **An exit code does not mean the permission landed.** Every grant is confirmed by re-reading
  `checkSelfPermission`. The plan is built from `PackageManager` alone, so a launch with nothing to
  grant never runs `su`.
- **The capture is claimed, not asked about.** `grantFatal` takes the same monitor `LogcatCapture.
  start()` holds, so exactly one of the two wins. A check-then-act cannot be repaired by checking
  again.

The sweep also refuses to spend privilege in a process the user did not open. `Application.onCreate`
runs on every process start, and Loki exports `LokiDocumentsProvider` with a `DOCUMENTS_PROVIDER`
filter — so DocumentsUI starts this process whenever any app opens a file picker, and the sticky
Shizuku callback re-enters the sweep there too. Ungated on a rooted device that means a root-manager
prompt over somebody else's picker, then the fatal grant, then `am start` putting Loki in the
foreground on top of whatever the user was doing. `MainActivity.onCreate()` is what releases the
sweep; `Loki.onCreate()` still registers the listener, because `ShizukuProvider` is installed before
it and the sticky delivery has usually already happened.

Deliberately not here: no `pm revoke` counterpart, and no hardcoded permission list — scope is
decided by the device, so adding a permission to the manifest needs no code edit.

## Testing

- [x] Builds on JDK 21: `./gradlew assembleDebug testDebugUnitTest :app:compileDebugAndroidTestKotlin lintRelease assembleRelease`
- [x] Ran on a device / emulator

`testDebugUnitTest --rerun-tasks`: 3 suites, 35 tests, 0 failures, 0 errors, 0 skipped. R8 wrote no
`missing_rules.txt`. `check-doc-links.sh` clean over 12 files and 52 internal links. No `.github/`
change, so shellcheck and actionlint were not required.

**Privilege mode(s) actually exercised:** Shizuku only.

The available hardware is a non-rooted Xiaomi and an emulator with no `su`. So the root grant, the
armed relaunch, root-first capture and the new headless-start gate are reasoned from the platform's
sources and are **unexercised on a device**. If the root path is wrong, the failure mode is that the
grant does not happen and Loki behaves exactly as it does today.

## Screenshots / recordings

None — the visible change is a status row in Settings.

## Checklist

- [x] Scoped to the stated purpose — no unrelated edits, no drive-by reformatting
- [x] Targets `dev`
- [x] No `versionCode` change in `gradle.properties` — the bump goes in its own release PR
- [x] No secrets, keystores, `jks.properties` or local paths committed
- [x] Docs updated if this changes how Loki is used or built
- [x] If this touches the privileged surface: no unvalidated input reaches a shell string, and
      nothing sends a captured log anywhere the user did not choose

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic permission handling through Root or Shizuku.
  * Added permission status checks, retry flows, and persistence of prior grant results.
  * Added clear in-app prompts for granting permissions, including restart or close behavior.
  * Improved log capture reliability by prioritizing Root and falling back to `READ_LOGS`.
* **Documentation**
  * Expanded setup and permission guidance, including access requirements and fallback behavior.
* **Tests**
  * Added coverage for permission planning, grant ordering, command validation, and manifest scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->